### PR TITLE
Bug@pause resume panics if day ended

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch-card"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,26 +96,30 @@ fn punch_out(now: &DateTime<Utc>, mut day: Day) {
 }
 
 fn take_break(now: &DateTime<Utc>, mut day: Day) {
-    if let Ok(_) = day.start_break(&now) {
+    let break_result = day.start_break(&now);
+    if let Ok(_) = break_result {
         println!("Taking a break at '{}'", &now);
         write_day(&day);
-        day.end_day_at(&now).expect("We should be able to end the day");
+        if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
         summarise_time(&day);
     }
     else {
-        print!("Can't take a break: Already on a break!")
+        let msg = break_result.unwrap_err();
+        println!("{}", msg);
     }
 }
 
 fn resume(now: &DateTime<Utc>, mut day: Day) {
-    if let Ok(_) = day.end_current_break_at(&now) {
+    let resume_result = day.end_current_break_at(&now);
+    if let Ok(_) = resume_result {
         println!("Back to work at '{}'", &now);
         write_day(&day);
-        day.end_day_at(&now).expect("We should be able to end the day");
+        if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
         summarise_time(&day);
     }
     else {
-        println!("Can't end the break: Not on a break!")
+        let msg = resume_result.unwrap_err();
+        println!("{}", msg);
     }
 }
 

--- a/src/utils/day.rs
+++ b/src/utils/day.rs
@@ -188,6 +188,10 @@ impl Day {
     }
 
     pub fn start_break(&mut self, at: &DateTime<Utc>) -> Result<(), &str> {
+        if self.has_ended() {
+            return Err("Can't start a break because day is already over!")
+        }
+
         if self.on_break {
             return Err("Can't start a break because day is already on break");
         }
@@ -205,6 +209,10 @@ impl Day {
     }
 
     pub fn end_current_break_at(&mut self, at: &DateTime<Utc>) -> Result<(), &str> {
+        if self.has_ended() {
+            return Err("Can't end the break because day is already over!")
+        }
+
         if !self.on_break {
             return Err("Can't end the break: currently not on break!");
         }


### PR DESCRIPTION
Fixes a bug that causes the script to panic if we pause or resume once the day has already ended.
This solves issue #9 