### PR TITLE
Fix@adding time to do option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ impl SubCommand {
 fn main() {
     let env_args: Vec<String> = args().collect();
     let command_name: &String = &env_args[1];
-    let other_args: Vec<String> = env_args[1..].to_vec();
+    let other_args: Vec<String> = env_args[2..].to_vec();
     let command: SubCommand = SubCommand::from_string(command_name, other_args);
 
     setup();

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,8 @@ fn run_command(command: SubCommand, now: DateTime<Local>) {
             SubCommand::Summary(_) => summary(&now, day),
             SubCommand::View(_) => view_day(day),
             SubCommand::Edit(_) => edit_day(day),
-            SubCommand::In(_) | SubCommand::Invalid(_) => unreachable!("We shouldn't be processing punch in here"),
+            SubCommand::In(_) => unreachable!("'punch in' commands shouldn't be being processed"),
+            SubCommand::Invalid(_) => unreachable!("Invalid commands shouldn't be being processed here"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,11 +95,17 @@ fn punch_in(now: &DateTime<Local>, other_args: Vec<String>) {
 
 fn get_time_to_do_for_day(other_args: Vec<String>) -> u64 {
     if other_args.len() == 0 {
-        return get_default_day_in_minutes();
+        let default_ttd: u64 = get_default_day_in_minutes();
+        println!("No time to do for the day provided. Using the default value ({}).", default_ttd);
+        println!("You can use `punch edit` to edit this value if this doesn't suit.");
+        return default_ttd;
     }
     let first_arg: Result<u64, std::num::ParseIntError> = other_args[0].parse::<u64>();
     return match first_arg {
-        Ok(ttd) => ttd,
+        Ok(ttd) => {
+            println!("Time to do for today: {}", ttd);
+            ttd
+        },
         Err(_) => {
             let ttd: u64 = get_default_day_in_minutes();
             println!("'{}' is not a valid value for time to do today. Using default instead ({}).", other_args[0], ttd);

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ impl SubCommand {
     }
 
     fn get_allowed_strings() -> Vec<String> {
-        return Vec::from(["in", "out", "pause", "resume", "summary", "view", "edit"].map(|x| x.to_string()));
+        return Vec::from(["in", "out", "pause", "resume", "summary", "view", "edit"].map(|x: &str| x.to_string()));
     }
 }
 
@@ -100,7 +100,7 @@ fn get_time_to_do_for_day(other_args: Vec<String>) -> u64 {
     return match first_arg {
         Ok(ttd) => ttd,
         Err(_) => {
-            let ttd = get_default_day_in_minutes();
+            let ttd: u64 = get_default_day_in_minutes();
             println!("'{}' is not a valid value for time to do today. Using default instead ({})", other_args[0], ttd);
             ttd
         },
@@ -131,7 +131,7 @@ fn punch_out(now: &DateTime<Local>, mut day: Day) {
 }
 
 fn take_break(now: &DateTime<Local>, mut day: Day) {
-    let break_result = day.start_break(&now);
+    let break_result: Result<(), &str> = day.start_break(&now);
     if let Ok(_) = break_result {
         println!("Taking a break at '{}'", &now);
         write_day(&day);
@@ -146,7 +146,7 @@ fn take_break(now: &DateTime<Local>, mut day: Day) {
 }
 
 fn resume(now: &DateTime<Local>, mut day: Day) {
-    let resume_result = day.end_current_break_at(&now);
+    let resume_result: Result<(), &str> = day.end_current_break_at(&now);
     if let Ok(_) = resume_result {
         println!("Back to work at '{}'", &now);
         write_day(&day);
@@ -180,7 +180,7 @@ fn edit_day(day: Day) {
 
 
 fn summary(now: &DateTime<Local>, mut day: Day) {
-    let end_result = day.end_day_at(&now);
+    let end_result: Result<(), &str> = day.end_day_at(&now);
     match end_result {
         Ok(_) => (),
         _ => (),
@@ -190,7 +190,7 @@ fn summary(now: &DateTime<Local>, mut day: Day) {
 
 
 fn summarise_time(day: &Day) {
-    let time_left: i64 = day.get_time_left().expect("Day is over so we should be able to calculate time done!");
+    let time_left: i64 = day.get_time_left().expect("Day is over so we should be able to calculate time left!");
 
     let mut config: Config = get_config();
     config.update_minutes_behind(time_left);

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,12 +190,12 @@ fn summary(now: &DateTime<Local>, mut day: Day) {
 
 
 fn summarise_time(day: &Day) {
-    let time_so_far: i64 = day.get_time_done().expect("Day is over so we should be able to calculate time done!");
+    let time_left: i64 = day.get_time_left().expect("Day is over so we should be able to calculate time done!");
+
     let mut config: Config = get_config();
-    let time_left: i64 = config.day_in_minutes() - time_so_far;
     config.update_minutes_behind(time_left);
 
-    println!("Time done today: {}", time_so_far);
+    println!("Time done today: {}", day.get_time_done().unwrap());
     println!("Time left today: {}", time_left);
     println!("Minutes behind overall: {}", config.minutes_behind());
     println!("Minutes behind since last fall behind: {}", config.minutes_behind_non_neg());

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,8 @@ fn get_time_to_do_for_day(other_args: Vec<String>) -> u64 {
         Ok(ttd) => ttd,
         Err(_) => {
             let ttd: u64 = get_default_day_in_minutes();
-            println!("'{}' is not a valid value for time to do today. Using default instead ({})", other_args[0], ttd);
+            println!("'{}' is not a valid value for time to do today. Using default instead ({}).", other_args[0], ttd);
+            println!("You can use `punch edit` to edit this value if this doesn't suit.");
             ttd
         },
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,12 +69,12 @@ fn run_command(command: SubCommand, now: DateTime<Local>) {
         let day: Day = possible_day.unwrap();
 
         match command {
-            SubCommand::Out(other_args) => punch_out(&now, day),
-            SubCommand::Pause(other_args) => take_break(&now, day),
-            SubCommand::Resume(other_args) => resume(&now, day),
-            SubCommand::Summary(other_args) => summary(&now, day),
-            SubCommand::View(other_args) => view_day(day),
-            SubCommand::Edit(other_args) => edit_day(day),
+            SubCommand::Out(_) => punch_out(&now, day),
+            SubCommand::Pause(_) => take_break(&now, day),
+            SubCommand::Resume(_) => resume(&now, day),
+            SubCommand::Summary(_) => summary(&now, day),
+            SubCommand::View(_) => view_day(day),
+            SubCommand::Edit(_) => edit_day(day),
             SubCommand::In(_) | SubCommand::Invalid(_) => unreachable!("We shouldn't be processing punch in here"),
         }
     }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -67,7 +67,6 @@ pub fn create_default_config_if_not_exists() {
     }
 }
 
-
 pub fn get_config() -> Config {
     let config_path: String = expand_path(&(BASE_DIR.to_owned() + &(CONFIG_FILE.to_owned())));
     let config: Config = read_config(&config_path);

--- a/src/utils/day.rs
+++ b/src/utils/day.rs
@@ -1,4 +1,4 @@
-use std::{fmt, time};
+use std::fmt;
 use chrono::prelude::{DateTime, Local};
 use chrono::TimeZone;
 use chrono::Duration;
@@ -266,7 +266,7 @@ impl Day {
     pub fn get_total_break_time(&self) -> Option<i64> {
         return match self.on_break {
             true => None,
-            false => self.breaks.iter().map(|x| x.get_length()).sum(),
+            false => self.breaks.iter().map(|x: &Interval| x.get_length()).sum(),
         };
     }
 
@@ -310,14 +310,14 @@ pub fn get_day_file_path(now: &DateTime<Local>) -> String {
 
 
 pub fn write_day(day: &Day) {
-    let path = &get_day_file_path(&day.get_day_start().as_dt());
+    let path: &String = &get_day_file_path(&day.get_day_start().as_dt());
     write_file(path, day.as_string());
 }
 
 
 pub fn read_day(now: &DateTime<Local>) -> Result<Day, std::io::Error> {
-    let path = &get_day_file_path(&now);
-    let read_result = read_file(path);
+    let path: &String = &get_day_file_path(&now);
+    let read_result: Result<String, std::io::Error> = read_file(path);
     return match read_result {
         Ok(string) => Ok(Day::from_string(&string)),
         Err(err) => Err(err),

--- a/src/utils/day.rs
+++ b/src/utils/day.rs
@@ -284,6 +284,13 @@ impl Day {
     pub fn get_time_to_do(&self) -> u64 {
         return self.time_to_do;
     }
+
+    pub fn get_time_left(&self) -> Option<i64> {
+        return match self.get_time_done() {
+            Some(td) => Some(self.get_time_to_do() as i64 - td),
+            None => None,
+        }
+    }
 }
 
 

--- a/src/utils/day.rs
+++ b/src/utils/day.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, time};
 use chrono::prelude::{DateTime, Local};
 use chrono::TimeZone;
 use chrono::Duration;
@@ -151,17 +151,23 @@ pub struct Day {
     pub overall_interval: Interval,
     pub breaks: Vec<Interval>,
     pub on_break: bool,
+    pub time_to_do: u64,
 }
 
 impl Day {
-    pub fn new(start: &DateTime<Local>) -> Self {
-        return Self {overall_interval: Interval::new(start), breaks: Vec::new(), on_break: false};
+    pub fn new(start: &DateTime<Local>, time_to_do: u64) -> Self {
+        return Self {
+            overall_interval: Interval::new(start), 
+            breaks: Vec::new(), 
+            on_break: false, 
+            time_to_do: time_to_do,
+        };
     }
 
     #[allow(dead_code)]
-    pub fn new_now() -> Self {
+    pub fn new_now(time_to_do: u64) -> Self {
         let now: DateTime<Local> = Local::now();
-        return Self::new(&now);
+        return Self::new(&now, time_to_do);
     }
 
     pub fn end_day_at(&mut self, at: &DateTime<Local>) -> Result<(), &str> {
@@ -273,6 +279,10 @@ impl Day {
 
     pub fn get_day_path(&self) -> String {
         return get_day_file_path(&self.get_day_start().as_dt());
+    }
+
+    pub fn get_time_to_do(&self) -> u64 {
+        return self.time_to_do;
     }
 }
 


### PR DESCRIPTION
We can now add an optional argument to `punch in` that specifies the number of minutes to be done today. This can also be edited using `punch edit`.

This solves issue #16 