### PR TITLE
Feature@adding timestamped notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "0.6.0"
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ enum SubCommand {
     Summary(Vec<String>),
     View(Vec<String>),
     Edit(Vec<String>),
+    Note(Vec<String>),
     Invalid(String),
 }
 
@@ -26,12 +27,13 @@ impl SubCommand {
             "summary" => Self::Summary(other_args),
             "view" => Self::View(other_args),
             "edit" => Self::Edit(other_args),
+            "note" => Self::Note(other_args),
             other => Self::Invalid(other.to_string()),
         }
     }
 
     fn get_allowed_strings() -> Vec<String> {
-        return Vec::from(["in", "out", "pause", "resume", "summary", "view", "edit"].map(|x: &str| x.to_string()));
+        return Vec::from(["in", "out", "pause", "resume", "summary", "view", "edit", "note"].map(|x: &str| x.to_string()));
     }
 }
 
@@ -75,6 +77,7 @@ fn run_command(command: SubCommand, now: DateTime<Local>) {
             SubCommand::Summary(_) => summary(&now, day),
             SubCommand::View(_) => view_day(day),
             SubCommand::Edit(_) => edit_day(day),
+            SubCommand::Note(other_args) => add_note_to_today(&now, day, other_args),
             SubCommand::In(_) => unreachable!("'punch in' commands shouldn't be being processed"),
             SubCommand::Invalid(_) => unreachable!("Invalid commands shouldn't be being processed here"),
         }
@@ -196,6 +199,19 @@ fn summary(now: &DateTime<Local>, mut day: Day) {
     }
     let mut config: Config = get_config();
     summarise_time(&day, &mut config);
+}
+
+
+fn add_note_to_today(now: &DateTime<Local>, mut day: Day, other_args: Vec<String>) {
+    if other_args.len() == 0 {
+        println!("'punch note' requires a msg argument!")
+    }
+    else if other_args.len() > 1 {
+        println!("'punch note' takes a single argument. Consider wrapping your message in quotes")
+    }
+    let msg: String = (&other_args[0]).to_string();
+    day.add_note(now, &msg);
+    write_day(&day);
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,11 +207,14 @@ fn add_note_to_today(now: &DateTime<Local>, mut day: Day, other_args: Vec<String
         println!("'punch note' requires a msg argument!")
     }
     else if other_args.len() > 1 {
-        println!("'punch note' takes a single argument. Consider wrapping your message in quotes")
+        println!("'punch note' takes a single argument. Consider wrapping your message in quotes.")
     }
-    let msg: String = (&other_args[0]).to_string();
-    day.add_note(now, &msg);
-    write_day(&day);
+    else {
+        let msg: String = (&other_args[0]).to_string();
+        day.add_note(now, &msg);
+        write_day(&day);
+        println!("New note '{}' added to today at '{}'.", msg, now);
+    }
 }
 
 

--- a/src/utils/day.rs
+++ b/src/utils/day.rs
@@ -169,6 +169,7 @@ pub struct Day {
     pub breaks: Vec<Interval>,
     pub on_break: bool,
     pub time_to_do: u64,
+    pub notes: Vec<Note>,
 }
 
 impl Day {
@@ -178,6 +179,7 @@ impl Day {
             breaks: Vec::new(), 
             on_break: false, 
             time_to_do: time_to_do,
+            notes: Vec::new(),
         };
     }
 
@@ -307,6 +309,11 @@ impl Day {
             Some(td) => Some(self.get_time_to_do() as i64 - td),
             None => None,
         }
+    }
+
+    pub fn add_note(&mut self, time: &DateTime<Local>, msg: &String) {
+        let new_note: Note = Note::new(time, msg);
+        self.notes.push(new_note);
     }
 }
 

--- a/src/utils/day.rs
+++ b/src/utils/day.rs
@@ -146,6 +146,23 @@ impl Interval {
     }
 }
 
+
+#[derive(Debug,Serialize,Deserialize)]
+pub struct Note {
+    time: Dt,
+    msg: String,
+}
+
+impl Note {
+    pub fn new(time: &DateTime<Local>, msg: &String) -> Self {
+        return Note {
+            time: Dt(*time),
+            msg: msg.to_string(),
+        };
+    }
+}
+
+
 #[derive(Debug,Serialize,Deserialize)]
 pub struct Day {
     pub overall_interval: Interval,


### PR DESCRIPTION
Adding a new subcommand (`punch note <msg>`) that allows us to add notes about the day.
Just wrap the note in quotes if it contains spaces.

This fully solves issue #5.