### PR TITLE
Feature@easily edit config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -68,9 +68,13 @@ pub fn create_default_config_if_not_exists() {
 }
 
 pub fn get_config() -> Config {
-    let config_path: String = expand_path(&(BASE_DIR.to_owned() + &(CONFIG_FILE.to_owned())));
+    let config_path: String = get_config_path();
     let config: Config = read_config(&config_path);
     return config;
+}
+
+pub fn get_config_path() -> String {
+    return expand_path(&(BASE_DIR.to_owned() + &(CONFIG_FILE.to_owned())));
 }
 
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,6 @@
 mod file_io;
 pub use file_io::{expand_path, read_file, write_file, create_dir_if_not_exists, create_base_dir_if_not_exists, BASE_DIR};
 mod config;
-pub use config::{Config, create_default_config_if_not_exists, get_config, update_config};
+pub use config::{Config, create_default_config_if_not_exists, get_config_path, get_config, update_config};
 mod day;
 pub use day::{Day, get_current_day, read_day, write_day, get_day_file_path, create_daily_dir_if_not_exists};


### PR DESCRIPTION
We can now use `punch edit-config` to edit the config in Vim rather than having to find the file.

This partially solves issue #17.