### PR TITLE
Fix@issue with edit commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 
 [dependencies]

--- a/src/utils/file_io.rs
+++ b/src/utils/file_io.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::Path;
 use std::env::var;
 
-pub const BASE_DIR: &str = "~/.punch-card-edit-test/";
+pub const BASE_DIR: &str = "~/.punch-card/";
 
 pub fn write_file(path: &str, contents: String) {
     let path_to_write: String = expand_path(path);

--- a/src/utils/file_io.rs
+++ b/src/utils/file_io.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::path::Path;
 use std::env::var;
 
-pub const BASE_DIR: &str = "~/.punch-card/";
+pub const BASE_DIR: &str = "~/.punch-card-edit-test/";
 
 pub fn write_file(path: &str, contents: String) {
     let path_to_write: String = expand_path(path);
@@ -74,7 +74,10 @@ pub trait SafeFileEdit<T:FromString<T,E> + ToFile, E>: ToFile + FromString<T, E>
         let yaml_str: String = read_file(&temp_path).unwrap();
         let new_result: Result<T, E> = T::try_from_string(&yaml_str);
         match new_result {
-            Ok(new_value) => new_value.write(),
+            Ok(new_value) => {
+                std::process::Command::new("rm").arg(&std_path).output().expect("Failed to clean up the temporary data!");
+                new_value.write();
+            },
             Err(_) => println!("Invalid Config created. Please try again"),
         };
         std::process::Command::new("rm").arg(&temp_path).output().expect("Failed to clean up the temporary data!");


### PR DESCRIPTION
Edit commands kept on creating bad files when the edit shortened the file. It seems to keep the "extra lines" from the old file around. This PR makes it so that we delete the original before writing the new one.

This PR should solve issue #33 