### PR TITLE
Improvements/bug-fixes after 2.0 

### DIFF
--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -65,7 +65,7 @@ impl Day {
         self.timeblocks.last_mut()
             .expect("Expected there to be an ongoing block!")
             .end_at(at);
-        
+        self.on_break = false;
         return Ok(());
     }
 
@@ -87,7 +87,6 @@ impl Day {
         else {
             self.tasks.insert(task_name, vec![new_ind]);
         }
-        self.on_break = false;
         return Ok(());
     }
 


### PR DESCRIPTION
This adds one feature and several bug fixes:
Feature:
- Default task after resuming a break is the one from before the break (Issue #38 )

Bug fixes:
- Summary panics when on break (Issue #42 )
- We can now no longer start a break when on a break (Issue #44 )
- Summary times didn't include last/current block (Issue #43 )
