### PR TITLE
Adding block counts in summary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2021"
 
 [dependencies]

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -192,7 +192,7 @@ pub fn add_summary_to_today(mut day: Day, other_args: Vec<String>) {
 fn summarise_time(day: &Day, config: &mut Config) {
     let time_left: i64 = day.get_time_left_secs().expect("Day is over so we should be able to calculate time left!");
     let break_time: i64 = day.get_total_break_time_secs().expect("Day is over so we should be able to calculate total break time!");
-    let task_summaries: HashMap<String, (i64, u64)> = day.get_task_times_and_blocks_secs();
+    let task_summaries: HashMap<String, (i64, u64)> = day.get_task_times_secs_and_num_blocks();
     let total_blocks: u64 = day.get_total_timeblocks();
     let total_blocks_without_breaks: u64 = day.get_total_timeblocks_without_breaks();
     config.update_minutes_behind(time_left / 60);

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -192,17 +192,21 @@ pub fn add_summary_to_today(mut day: Day, other_args: Vec<String>) {
 fn summarise_time(day: &Day, config: &mut Config) {
     let time_left: i64 = day.get_time_left_secs().expect("Day is over so we should be able to calculate time left!");
     let break_time: i64 = day.get_total_break_time_secs().expect("Day is over so we should be able to calculate total break time!");
-    let task_times: HashMap<String, i64> = day.get_task_times_secs();
+    let task_summaries: HashMap<String, (i64, u64)> = day.get_task_times_and_blocks_secs();
+    let total_blocks: u64 = day.get_total_timeblocks();
+    let total_blocks_without_breaks: u64 = day.get_total_timeblocks_without_breaks();
     config.update_minutes_behind(time_left / 60);
 
     let time_done_secs = day.get_time_done_secs().unwrap();
     println!("Time done today: {} m {} s", time_done_secs / 60, time_done_secs % 60);
     println!("Total time spent on break: {} m {} s", break_time / 60, break_time % 60);
     println!("Time left today: {} m {} s", time_left / 60, time_left % 60);
+    println!("Total task blocks (including breaks): {}", total_blocks);
+    println!("Total task blocks (excluding breaks): {}", total_blocks_without_breaks);
     println!("Latest task: '{}'", day.get_latest_task_name());
-    println!("Task times:");
-    for (task_name, time) in task_times.into_iter() {
-        println!("\t{}: {} m {} s", task_name, time / 60, time % 60);
+    println!("Task times, blocks:");
+    for (task_name, (time, blocks)) in task_summaries.into_iter() {
+        println!("\t{}: {} m {} s, {} blocks", task_name, time / 60, time % 60, blocks);
     }
     println!("Minutes behind overall: {}", config.minutes_behind());
     println!("Minutes behind since last fall behind: {}", config.minutes_behind_non_neg());

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use crate::commands::core::{
 use crate::utils::file_io::{create_base_dir_if_not_exists};
 use crate::utils::config::{create_default_config_if_not_exists};
 
-const VERSION: &str = "2.2.2";
+const VERSION: &str = "2.2.3";
 
 
 #[derive(PartialEq)]

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -234,6 +234,14 @@ impl Day {
         let summary: WorkSummary = WorkSummary::new(category, project, task, summary);
         self.summaries.push(summary);
     }
+
+    pub fn get_total_timeblocks(&self) -> u64 {
+        return self.timeblocks.len() as u64;
+    }
+
+    pub fn get_total_timeblocks_without_breaks(&self) -> u64 {
+        return self.get_total_timeblocks() - (self.breaks.len() as u64);
+    }
 }
 
 impl FromString<Day, serde_yaml::Error> for Day {

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -199,7 +199,7 @@ impl Day {
         );
     }
 
-    pub fn get_task_times_and_blocks_secs(&self) -> HashMap<String, (i64, u64)> {
+    pub fn get_task_times_secs_and_num_blocks(&self) -> HashMap<String, (i64, u64)> {
         return HashMap::from_iter(
             self.tasks.clone().into_iter().map(
                 |(x, y): (String, Vec<usize>)| (

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -199,6 +199,25 @@ impl Day {
         );
     }
 
+    pub fn get_task_times_and_blocks_secs(&self) -> HashMap<String, (i64, u64)> {
+        return HashMap::from_iter(
+            self.tasks.clone().into_iter().map(
+                |(x, y): (String, Vec<usize>)| (
+                    x, 
+                    (
+                        y.clone().into_iter()
+                        .map(
+                            |i: usize| 
+                            self.timeblocks[i].get_length_secs().unwrap_or(0)
+                        )
+                        .sum(),
+                        y.len() as u64
+                    )
+                )
+            )
+        );
+    }
+
     pub fn get_total_break_time_secs(&self) -> Option<i64> {
         return match self.on_break {
             true => None,


### PR DESCRIPTION
Adds information about number of timeblocks in a day and per task to the summary.

This solves issue #56 .