### PR TITLE
Patch/fix for panic no command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "2.2.4"
+version = "2.2.5"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The config file will be stored at `~/.punch-card/punch.cfg`. This stores the len
 At the moment, the only way to install is to build the program locally. You'll need to have Rust and Cargo installed as well as Vim. In addition, this has only been tested on a Mac (though it should work on Linux and Windows too, with different instructions).
 
 1. Clone this repository to your computer.
-2. Run 'cargo build -- release'. The executable will then appear in `/target/release/punch`
+2. Run 'cargo build --release'. The executable will then appear in `/target/release/punch`
 3. Copy it to somewhere on your PATH
 
 Alternatively, you can run the included `install.sh` after you have cloned your repository, provided you have a `/usr/local/bin/` directory. You will also need to add `usr/local/bin/` to your PATH if it hasn't been added already.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,11 @@ mod units;
 mod utils;
 use crate::units::day::{create_daily_dir_if_not_exists,get_current_day,Day};
 use crate::commands::core::{
-    punch_in, 
-    punch_out, 
-    take_break, 
-    resume, 
-    view_day, 
+    punch_in,
+    punch_out,
+    take_break,
+    resume,
+    view_day,
     edit_day,
     switch_to_new_task,
     update_current_task_name,
@@ -48,7 +48,7 @@ enum SubCommand {
 
 impl SubCommand {
     fn from_string(name: &String, other_args: Vec<String>) -> Self {
-        return match name.to_owned().trim() {
+        match name.to_owned().trim() {
             "in" => Self::In(other_args),
             "out" => Self::Out(other_args),
             "pause" => Self::Pause(other_args),
@@ -68,19 +68,26 @@ impl SubCommand {
     }
 
     fn get_allowed_strings() -> Vec<String> {
-        return Vec::from(
+        Vec::from(
             [
-                "in", "out", "pause", "resume", "summary", "view", "edit", 
+                "in", "out", "pause", "resume", "summary", "view", "edit",
                 "task", "note", "edit-config", "add-summary", "update-task",
                 "version", "-v", "--version"
             ].map(|x: &str| x.to_string())
-        );
+        )
     }
 }
 
 fn main() {
     let env_args: Vec<String> = args().collect();
-    let command_name: &String = &env_args[1];
+    let command_name: &String;
+
+    if let Some(name) = env_args.get(1) {
+        command_name = name;
+    } else {
+        handle_invalid_cmd(" ");
+        return;
+    }
     let other_args: Vec<String> = env_args[2..].to_vec();
     let command: SubCommand = SubCommand::from_string(command_name, other_args);
 
@@ -134,7 +141,7 @@ fn run_command(command: SubCommand, now: DateTime<Local>) {
     }
 }
 
-fn handle_invalid_cmd(command: &String) {
+fn handle_invalid_cmd(command: &str) {
     eprintln!("'{}' is not a valid subcommand for punch. Try one of the following:", command);
     for str_subcommand in SubCommand::get_allowed_strings() {
         eprintln!("\t{}", str_subcommand);

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use crate::commands::core::{
 use crate::utils::file_io::{create_base_dir_if_not_exists};
 use crate::utils::config::{create_default_config_if_not_exists};
 
-const VERSION: &str = "2.2.4";
+const VERSION: &str = "2.2.5";
 
 
 #[derive(PartialEq)]
@@ -48,7 +48,7 @@ enum SubCommand {
 
 impl SubCommand {
     fn from_string(name: &String, other_args: Vec<String>) -> Self {
-        match name.to_owned().trim() {
+        return match name.to_owned().trim() {
             "in" => Self::In(other_args),
             "out" => Self::Out(other_args),
             "pause" => Self::Pause(other_args),
@@ -68,7 +68,7 @@ impl SubCommand {
     }
 
     fn get_allowed_strings() -> Vec<String> {
-        Vec::from(
+        return Vec::from(
             [
                 "in", "out", "pause", "resume", "summary", "view", "edit",
                 "task", "note", "edit-config", "add-summary", "update-task",


### PR DESCRIPTION
This PR fixes the panic that happens when no command is given, i.e. `punch  <None>`. It also fixes a typo in the README.md.