### PR TITLE
Adding Summary and Past Commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4.23"
+regex = "1.11.1"
 serde = {version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -11,22 +11,25 @@ Once it's installed you can start your day by running `punch in`. The following 
 - `pause`: To take a break.
 - `resume`: To resume after you come back from a break. You should give it a new task name for the black about to start.
 - `out`: Ends the day. If you end the day while on a break, the break is automatically ended. This also works if you end up working after midnight too.
-- `back-in`: If you end the day accidentally/learn later that you need to punch back in, use this command.
 - `task`: Used to start a new time-block for working on a new task. Used for task time-tracking.
 - `view`: Allows you to see a string representation of your day.
-- `view-past`: Allows you to see a string representation of some day in the past. It takes one argument: A date string in yyyy-mm-dd format.
 - `edit`: Allows you to edit your day so far.
 - `summary`: Prints a summary of your day. Tells you how many minutes you have worked, how many minutes you have left and how far behind on time you have fallen (for instance, if you finished early one of the days and need to make that time back). It also gives a summary of the tasks you've done and the time spent too.
+- `note`: Used to add a note at the current time.
+- `add-summary`: Used to add a summary for what's been done for a particular task.
+
+In addition, once you've "punched out" you can run:
+- `back-in`: If you end the day accidentally/learn later that you need to punch back in, use this command.
+
+The following commands don't require you to have "punched in" for the day yet:
+- `view-past`: Allows you to see a string representation of some day in the past. It takes one argument: A date string in yyyy-mm-dd format.
 - `summary-past`: Does the same as `summary` except you can pick some day in the past. It takes as argument a date string in yyyy-mm-dd format.
 - `summarise-week`: This prints a similar summary to the last two commands except it does it for a week's worth of days. Ran without argument, it summarises the last 7 days including today. Otherwise, you can provide it with a single date string argument, which allows you to summarise the week ending on that date. In addition, you can provide it with a second argument that specifies the time behind when starting the week, which adds an extra summary line.
 - `summarise-days`: This does the same as the previous command except you have to specify the start and end dates. If only one date is provided, it will just summarise that one day, if two date strings are provided, it summarises those days (inclusive). You can also provide a third argument indicating the time behind at the start of the period.
-- `note`: Used to add a note at the current time.
 - `edit-config`: Used to edit the configuration file for `punch`.
 - `view-config`: Used to view the configuration file for `punch`.
-- `add-summary`: Used to add a summary for what's been done for a particular task.
 
 The config file will be stored at `~/.punch-card/punch.cfg`. This stores the length of your day in minutes (480 minutes or 8 hours by default) as well as storing how many minutes you have fallen behind.
-
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ Once it's installed you can start your day by running `punch in`. The following 
 - `back-in`: If you end the day accidentally/learn later that you need to punch back in, use this command.
 - `task`: Used to start a new time-block for working on a new task. Used for task time-tracking.
 - `view`: Allows you to see a string representation of your day.
+- `view-past`: Allows you to see a string representation of some day in the past. It takes one argument: A date string in yyyy-mm-dd format.
 - `edit`: Allows you to edit your day so far.
-- `summary`: Prints a summary of your day. Tells you how many minutes you have worked, how many minutes you have left and how far behind on time you have fallen (for instance, if you finished early one of the days and need to make that time back). 
+- `summary`: Prints a summary of your day. Tells you how many minutes you have worked, how many minutes you have left and how far behind on time you have fallen (for instance, if you finished early one of the days and need to make that time back). It also gives a summary of the tasks you've done and the time spent too.
+- `summary-past`: Does the same as `summary` except you can pick some day in the past. It takes as argument a date string in yyyy-mm-dd format.
+- `summarise-week`: This prints a similar summary to the last two commands except it does it for a week's worth of days. Ran without argument, it summarises the last 7 days including today. Otherwise, you can provide it with a single date string argument, which allows you to summarise the week ending on that date. In addition, you can provide it with a second argument that specifies the time behind when starting the week, which adds an extra summary line.
+- `summarise-days`: This does the same as the previous command except you have to specify the start and end dates. If only one date is provided, it will just summarise that one day, if two date strings are provided, it summarises those days (inclusive). You can also provide a third argument indicating the time behind at the start of the period.
 - `note`: Used to add a note at the current time.
 - `edit-config`: Used to edit the configuration file for `punch`.
 - `view-config`: Used to view the configuration file for `punch`.

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -6,6 +6,7 @@ use crate::utils::file_io::SafeFileEdit;
 use crate::units::day::{
     Day,
     read_day,
+    read_day_from_date_str,
     write_day};
 
 use crate::utils::config::{Config, get_config, update_config};
@@ -195,6 +196,33 @@ fn get_new_task_block_from_args(other_args: Vec<String>) -> Result<String, Strin
 pub fn view_day(day: Day) {
     println!("Here's the day so far: \n");
     println!("{}", day.as_string());
+}
+
+pub fn view_past(other_args: Vec<String>) {
+    let arg_result: Result<String, String> = parse_args_for_view_past(other_args);
+    
+    if let Err(msg) = arg_result {
+        eprintln!("{}", msg);
+        exit(1);
+    }
+    else if let Ok(date_str) = arg_result {
+        if let Ok(day) = read_day_from_date_str(&date_str) {
+            println!("Here is {}:\n", date_str);
+            println!("{}", day.as_string());
+        }
+        else {
+            eprintln!("'{}' does not have a day associated with it!", date_str);
+        }
+    }
+    
+}
+
+fn parse_args_for_view_past(other_args: Vec<String>) -> Result<String, String> {
+    return match other_args.len() {
+        0 => Err("'punch view-past' needs a new task name!".to_string()),
+        1 => Ok(other_args[0].to_owned()),
+        _ => Err("'punch view-past' should have at most one argument!".to_string()),
+    };
 }
 
 pub fn edit_day(day: Day) {

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -81,7 +81,7 @@ pub fn take_break(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) 
 
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day);
+        let summary_result = print_day_summary(day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
@@ -118,7 +118,7 @@ pub fn resume(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) {
         write_day(&day);
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day);
+        let summary_result = print_day_summary(day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
@@ -158,7 +158,7 @@ pub fn punch_back_in(now: &DateTime<Local>, other_args: Vec<String>, mut day: Da
         config.update_minutes_behind(-seconds_left_before / 60);
         update_config(config);
 
-        let summary_result = print_day_summary(day);
+        let summary_result = print_day_summary(day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
@@ -193,7 +193,7 @@ pub fn switch_to_new_task(now: &DateTime<Local>, mut day: Day, other_args: Vec<S
         write_day(&day);
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day);
+        let summary_result = print_day_summary(day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
@@ -305,7 +305,7 @@ pub fn update_current_task_name(now: &DateTime<Local>, mut day: Day, other_args:
         write_day(&day);
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day);
+        let summary_result = print_day_summary(day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -53,9 +53,13 @@ pub fn punch_out(now: &DateTime<Local>, mut day: Day) {
     if let Ok(_) = day.end_day_at(&now) {
         println!("Punching out for the day at '{}'", &day.get_day_end_as_str().unwrap().trim());
         write_day(&day);
-
-
-        update_time_behind(day);
+        match update_time_behind(day) {
+            Ok(()) => (),
+            Err(err_msg) => {
+                eprintln!("{}", err_msg);
+                exit(1);
+            }
+        }
     }
     else {
         println!("Can't punch out: Already punched out for the day!");
@@ -257,7 +261,7 @@ pub fn add_summary_to_today(mut day: Day, other_args: Vec<String>) {
         day.add_summary(category, project, task, summary);
         write_day(&day);
     }
-
+}
 
 pub fn view_config() {
     println!("Here's the current config: \n");
@@ -320,7 +324,7 @@ fn get_new_task_name_from_args(other_args: Vec<String>) -> Result<String, String
         1 => Ok(other_args[0].to_owned()),
         _ => Err("'punch update-task' should have at most one argument!".to_string()),
     };
-}}
+}
 
 
 fn update_time_behind(day: Day) -> Result<(), String> {

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -240,9 +240,8 @@ pub fn view_past(other_args: Vec<String>) {
 
 fn parse_args_for_view_past(other_args: Vec<String>) -> Result<String, String> {
     return match other_args.len() {
-        0 => Err("'punch view-past' needs a new task name!".to_string()),
         1 => Ok(other_args[0].to_owned()),
-        _ => Err("'punch view-past' should have at most one argument!".to_string()),
+        _ => Err("'punch view-past' should have exactly one argument!".to_string()),
     };
 }
 

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::process::exit;
 use chrono::prelude::{DateTime, Local};
 use crate::commands::day_summaries::print_day_summary;
@@ -78,9 +77,9 @@ pub fn take_break(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) 
 
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day):
-        if Err(err_msg) = summary_result {
-            eprintln!(err_msg);
+        let summary_result = print_day_summary(day);
+        if let Err(err_msg) = summary_result {
+            eprintln!("{}", err_msg);
             exit(1);
         }
     }
@@ -115,9 +114,9 @@ pub fn resume(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) {
         write_day(&day);
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day):
-        if Err(err_msg) = summary_result {
-            eprintln!(err_msg);
+        let summary_result = print_day_summary(day);
+        if let Err(err_msg) = summary_result {
+            eprintln!("{}", err_msg);
             exit(1);
         }
     }
@@ -155,9 +154,9 @@ pub fn punch_back_in(now: &DateTime<Local>, other_args: Vec<String>, mut day: Da
         config.update_minutes_behind(-seconds_left_before / 60);
         update_config(config);
 
-        let summary_result = print_day_summary(day):
-        if Err(err_msg) = summary_result {
-            eprintln!(err_msg);
+        let summary_result = print_day_summary(day);
+        if let Err(err_msg) = summary_result {
+            eprintln!("{}", err_msg);
             exit(1);
         }
     }
@@ -190,9 +189,9 @@ pub fn switch_to_new_task(now: &DateTime<Local>, mut day: Day, other_args: Vec<S
         write_day(&day);
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day):
-        if Err(err_msg) = summary_result {
-            eprintln!(err_msg);
+        let summary_result = print_day_summary(day);
+        if let Err(err_msg) = summary_result {
+            eprintln!("{}", err_msg);
             exit(1);
         }
     }
@@ -302,9 +301,9 @@ pub fn update_current_task_name(now: &DateTime<Local>, mut day: Day, other_args:
         write_day(&day);
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day):
-        if Err(err_msg) = summary_result {
-            eprintln!(err_msg);
+        let summary_result = print_day_summary(day);
+        if let Err(err_msg) = summary_result {
+            eprintln!("{}", err_msg);
             exit(1);
         }
     }
@@ -324,7 +323,7 @@ fn get_new_task_name_from_args(other_args: Vec<String>) -> Result<String, String
 }}
 
 
-fn update_time_behind(day: Day) -> Result<(), &str> {
+fn update_time_behind(day: Day) -> Result<(), String> {
     if day.has_ended() {
         let mut config: Config = get_config();
         let time_left: i64 = day.get_time_left_secs().expect("Day is over so we should have a time left!");
@@ -333,6 +332,6 @@ fn update_time_behind(day: Day) -> Result<(), &str> {
         return Ok(());
     }
     else {
-        return Err("Can't update time behind: The day isn't over yet");
+        return Err("Can't update time behind: The day isn't over yet".to_string());
     }
 }

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -187,7 +187,10 @@ pub fn summary(now: &DateTime<Local>, mut day: Day) {
     let end_result: Result<(), &str> = day.end_day_at(&now);
     match end_result {
         Ok(_) => (),
-        _ => (),
+        Err(err_msg) => {
+            eprintln!("Couldn't end day: {}", err_msg);
+            exit(1);
+        },
     }
     if let Err(err_msg) = print_day_summary(day, true) {
         eprintln!("{}", err_msg);

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -68,14 +68,13 @@ fn parse_args_for_summarise_days(args: Vec<String>) -> Result<(NaiveDate, NaiveD
         return Err(format!("First argument for summarise-days must be a date of the form 'YYYY-mm-dd'. Got: '{}'", args[0]));
     }
     let naive_start_date = naive_date_result.expect("Error for this has already been handled!");
-    let naive_end_date = if args.len() >= 2 {
+    let naive_end_date: NaiveDate = if args.len() >= 2 {
             let naive_end_date_result: Result<NaiveDate, chrono::ParseError>  = NaiveDate::parse_from_str(&args[1], "%Y-%m-%d");
             if let Err(_) = naive_end_date_result {
                 return Err(format!("Second argument for summarise-days must be a date of the form 'YYYY-mm-dd'. Got: '{}'", args[1]));
             }
-            naive_date_result.expect("Error for this has already been handled!")
+            naive_end_date_result.expect("Error for this has already been handled!")
         } else {naive_start_date};
-    
     let initial_time_behind_opt = if args.len() == 3 {
         let parse_result: Result<i64, std::num::ParseIntError> = args[2].parse::<i64>();
         if let Err(_) = parse_result {
@@ -113,18 +112,30 @@ pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_
         };
         days_aggregated.push(this_date_str.clone());
     }
-    
-    println!("Days aggregated: {}", days_aggregated.join(", "));
+    println!("Days aggregated: {}", render_list_of_dates_for_user_info(&days_aggregated));
     if days_not_there.len() > 0 {
-        println!("Days not there: {}", days_not_there.join(", "));
+        println!("Days not there: {}", render_list_of_dates_for_user_info(&days_not_there));
     }
     if days_not_ended.len() > 0 {
-        println!("Days not ended: {}", days_not_ended.join(", "));
+        println!("Days not ended: {}", render_list_of_dates_for_user_info(&days_not_ended));
     }
     let print_result: Result<(), String> = print_aggregated_day_summary(&aggregated, initial_time_behind_opt.is_some());
     if let Err(err_msg) = print_result {
         eprintln!("{}", err_msg);
         exit(1);
+    }
+}
+
+fn render_list_of_dates_for_user_info(dates: &Vec<String>) -> String {
+    let max_dates: usize = 5;
+    if dates.len() == max_dates {
+        return "None".to_string();
+    }
+    else if dates.len() <= 5 {
+        return dates.join(", ");
+    }
+    else {
+        return dates[..max_dates].join(", ") + ", ...";
     }
 }
 

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -5,6 +5,7 @@ use crate::units::day::{Day,read_day_from_date_str};
 use crate::units::aggregate_day::AggregateDay;
 use crate::utils::config::{Config, get_config};
 use crate::utils::dates_and_times::{get_local_now, DateRange};
+use crate::utils::misc::convert_input_to_seconds;
 
 pub fn summarise_week(args: Vec<String>) {
     match parse_args_for_summarise_week(args) {
@@ -34,9 +35,9 @@ fn parse_args_for_summarise_week(args: Vec<String>) -> Result<(NaiveDate, NaiveD
     let week_before: NaiveDate = current_date - Duration::days(6);
 
     let intial_time_behind_opt = if args.len() == 2 {
-            let parse_result: Result<i64, std::num::ParseIntError> = args[1].parse::<i64>();
-            if let Err(_) = parse_result {
-                return Err(format!("Second argument for summarise-week must be an integer. Got: {}", args[1]));
+            let parse_result: Result<i64, String> = convert_input_to_seconds(&args[1]);
+            if let Err(err_msg) = parse_result {
+                return Err(err_msg);
             }
             Some(parse_result.expect("Error from parsing i64 already handled!"))
         } else {None};
@@ -76,9 +77,9 @@ fn parse_args_for_summarise_days(args: Vec<String>) -> Result<(NaiveDate, NaiveD
             naive_end_date_result.expect("Error for this has already been handled!")
         } else {naive_start_date};
     let initial_time_behind_opt = if args.len() == 3 {
-        let parse_result: Result<i64, std::num::ParseIntError> = args[2].parse::<i64>();
-        if let Err(_) = parse_result {
-            return Err(format!("Third argument for summarise-days must be an integer. Got: {}", args[2]));
+        let parse_result: Result<i64, String> = convert_input_to_seconds(&args[2]);
+        if let Err(err_msg) = parse_result {
+            return Err(err_msg);
         }
         Some(parse_result.expect("Error for this has already been handled!"))
         } else {None};

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -1,4 +1,8 @@
+use chrono::prelude::{DateTime, Local};
 use std::process::exit;
+
+use crate::units::day::Day;
+use crate::utils::config::{Config, get_config};
 
 
 pub fn summary(now: &DateTime<Local>, mut day: Day) {
@@ -8,20 +12,20 @@ pub fn summary(now: &DateTime<Local>, mut day: Day) {
         _ => (),
     }
     if let Err(err_msg) = print_day_summary(day) {
-        eprintln(err_msg);
+        eprintln!("{}", err_msg);
         exit(1);
     }
 }
 
 
-fn print_day_summary(day: Day) -> Result<(), &str> {
+pub fn print_day_summary(day: Day) -> Result<(), String> {
     let config: Config = get_config();
     let time_behind_s: i64 = config.minutes_behind() * 60;
-    let summary_result: Result<String, &str> = day.render_human_readable_summary(time_behind_s);
+    let summary_result: Result<String, String> = day.render_human_readable_summary(Some(time_behind_s));
     
     return match summary_result {
         Ok(summary_str) => {
-            println!(summary_str);
+            println!("{}", summary_str);
             Ok(())
         },
         Err(err_msg) => Err(err_msg),

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -4,7 +4,7 @@ use std::process::exit;
 use crate::units::day::{Day,read_day_from_date_str};
 use crate::units::aggregate_day::AggregateDay;
 use crate::utils::config::{Config, get_config};
-use crate::utils::dates_and_times::{get_local_now, convert_date_to_date_str, DateRange};
+use crate::utils::dates_and_times::{get_local_now, DateRange};
 
 pub fn summarise_week(args: Vec<String>) {
     match parse_args_for_summarise_week(args) {

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -8,8 +8,8 @@ use crate::utils::dates_and_times::{get_local_now, convert_date_to_date_str, Dat
 
 pub fn summarise_week(args: Vec<String>) {
     match parse_args_for_summarise_week(args) {
-        Ok((start_date_str, end_date_str, initial_time_behind_opt)) => {
-            summarise_date_range(start_date_str, end_date_str, initial_time_behind_opt)
+        Ok((start_date, end_date, initial_time_behind_opt)) => {
+            summarise_date_range(start_date, end_date, initial_time_behind_opt)
         },
         Err(msg) => {
             eprintln!("{}", msg);
@@ -18,7 +18,7 @@ pub fn summarise_week(args: Vec<String>) {
     }
 }
 
-fn parse_args_for_summarise_week(args: Vec<String>) -> Result<(String, String, Option<i64>), String> {
+fn parse_args_for_summarise_week(args: Vec<String>) -> Result<(NaiveDate, NaiveDate, Option<i64>), String> {
     if args.len() > 2 {
         return Err("Too many args found for summarise_week".to_owned());
     }
@@ -41,16 +41,13 @@ fn parse_args_for_summarise_week(args: Vec<String>) -> Result<(String, String, O
             Some(parse_result.expect("Error from parsing i64 already handled!"))
         } else {None};
     
-    return Ok((
-        convert_date_to_date_str(current_date), 
-        convert_date_to_date_str(week_before), 
-        intial_time_behind_opt));
+    return Ok((week_before, current_date, intial_time_behind_opt));
 }
 
 pub fn summarise_days(args: Vec<String>) {
     match parse_args_for_summarise_days(args) {
-        Ok((start_date_str, end_date_str, initial_time_behind_opt)) => {
-            summarise_date_range(start_date_str, end_date_str, initial_time_behind_opt)
+        Ok((start_date, end_date, initial_time_behind_opt)) => {
+            summarise_date_range(start_date, end_date, initial_time_behind_opt)
         },
         Err(msg) => {
             eprintln!("{}", msg);
@@ -59,7 +56,7 @@ pub fn summarise_days(args: Vec<String>) {
     }
 }
 
-fn parse_args_for_summarise_days(args: Vec<String>) -> Result<(String, String, Option<i64>), String> {
+fn parse_args_for_summarise_days(args: Vec<String>) -> Result<(NaiveDate, NaiveDate, Option<i64>), String> {
     if args.len() == 0 {
         return Err("summarise-days must have at least one argument.".to_string());
     }
@@ -87,17 +84,10 @@ fn parse_args_for_summarise_days(args: Vec<String>) -> Result<(String, String, O
         Some(parse_result.expect("Error for this has already been handled!"))
         } else {None};
 
-    return Ok((
-        convert_date_to_date_str(naive_start_date), 
-        convert_date_to_date_str(naive_end_date), 
-        initial_time_behind_opt
-    ))
+    return Ok((naive_start_date, naive_end_date, initial_time_behind_opt))
 }
 
-pub fn summarise_date_range(start_date_str: String, end_date_str: String, initial_time_behind_opt: Option<i64>) {
-    let start_date = NaiveDate::parse_from_str(&start_date_str, "%Y-%m-%d").unwrap();
-    let end_date = NaiveDate::parse_from_str(&end_date_str, "%Y-%m-%d").unwrap();
-
+pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_time_behind_opt: Option<i64>) {
     let seed_time: i64 = initial_time_behind_opt.unwrap_or(0);
     let mut aggregated: AggregateDay = AggregateDay::new(seed_time);
 

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -91,6 +91,8 @@ pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_
     let seed_time: i64 = initial_time_behind_opt.unwrap_or(0);
     let mut aggregated: AggregateDay = AggregateDay::new(seed_time);
 
+    let local_now: DateTime<Local> = get_local_now();
+    let todays_date: NaiveDate = local_now.date_naive();
     let mut days_aggregated: Vec<String> = Vec::new();
     let mut days_not_there: Vec<String> = Vec::new();
     let mut days_not_ended: Vec<String> = Vec::new();
@@ -102,8 +104,17 @@ pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_
             days_not_there.push(this_date_str.clone());
             continue;
         }
-        let this_day: Day = this_day_result.expect("Already handled error!");
-        if !this_day.has_ended() {
+        let mut this_day: Day = this_day_result.expect("Already handled error!");
+        if !this_day.has_ended() && (local_date == todays_date) {
+            match this_day.end_day_at(&local_now) {
+                Ok(()) => (),
+                Err(err_msg) => {
+                    eprintln!("Failed to end today: {err_msg}");
+                    exit(1);
+                }
+            }
+        }
+        else if !this_day.has_ended() {
             days_not_ended.push(this_date_str.clone());
             continue;
         }

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -1,9 +1,70 @@
+use chrono::{NaiveDate, Duration};
 use chrono::prelude::{DateTime, Local};
 use std::process::exit;
+use std::mem;
 
-use crate::units::day::Day;
+
+use crate::units::day::{Day,read_day_from_date_str};
+use crate::units::aggregate_day::AggregateDay
 use crate::utils::config::{Config, get_config};
 
+struct DateRange(NaiveDate, NaiveDate);
+
+impl Iterator for DateRange {
+    type Item = NaiveDate;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0 <= self.1 {
+            let next = self.0 + Duration::days(1);
+            Some(mem::replace(&mut self.0, next))
+        } else {
+            None
+        }
+    }
+}
+
+pub fn summarise_week(args: Vec<String>) {}
+
+
+pub fn summarise_days(args: Vec<String>) {}
+
+pub fn summarise_date_range(start_date_str: String, end_date_str: String, initial_time_behind_opt: Option<i64>) {
+    let start_date = NaiveDate::parse_from_str(&start_date_str, "%Y-%m-%d").unwrap();
+    let end_date = NaiveDate::parse_from_str(&end_date_str, "%Y-%m-%d").unwrap();
+
+    let seed_time: i64 = initial_time_behind_opt.unwrap_or(0);
+    let mut aggregated: AggregateDay = AggregateDay::new(seed_time);
+    for local_date in DateRange(start_date, end_date) {
+        let this_date_str: String = local_date.format("%Y-%m-%d");
+        let this_day: Day = read_day_from_date_str(date_str);
+        aggregated.add_day(this_day);
+    }
+
+    let print_result: Result<(), String> = print_aggregated_day_summary(&aggregated, initial_time_behind_opt.is_some());
+    if let Err(err_msg) = print_result {
+        eprintln!("{}", err_msg);
+        exit(1);
+    }
+}
+
+pub fn print_aggregated_day_summary(aggregate_day: &AggregateDay, include_overall_time_behind: bool) -> Result<(), String> {
+    let summary_result: Result<String, String> = aggregate_day.render_human_readable_summary(include_overall_time_behind);    
+    return match summary_result {
+        Ok(summary_str) => {
+            println!("{}", summary_str);
+            Ok(())
+        },
+        Err(err_msg) => Err(err_msg),
+    }
+}
+
+
+pub fn summary_past(date_str: String) {
+    let day: Day = read_day_from_date_str(&date_str);
+    if let Err(err_msg) = print_day_summary(day, false) {
+        eprintln!("{}", err_msg);
+        exit(1);
+    }
+}
 
 pub fn summary(now: &DateTime<Local>, mut day: Day) {
     let end_result: Result<(), &str> = day.end_day_at(&now);
@@ -11,17 +72,22 @@ pub fn summary(now: &DateTime<Local>, mut day: Day) {
         Ok(_) => (),
         _ => (),
     }
-    if let Err(err_msg) = print_day_summary(day) {
+    if let Err(err_msg) = print_day_summary(day, true) {
         eprintln!("{}", err_msg);
         exit(1);
     }
 }
 
 
-pub fn print_day_summary(day: Day) -> Result<(), String> {
-    let config: Config = get_config();
-    let time_behind_s: i64 = config.minutes_behind() * 60;
-    let summary_result: Result<String, String> = day.render_human_readable_summary(Some(time_behind_s));
+pub fn print_day_summary(day: Day, use_config_for_time_behind: bool) -> Result<(), String> {
+    let time_behind_opt: Option<i64> = match use_config_for_time_behind {
+        true => {
+            let config: Config = get_config();
+            config.minutes_behind() * 60;
+        },
+        false => None,
+    };
+    let summary_result: Result<String, String> = day.render_human_readable_summary(time_behind_opt);
     
     return match summary_result {
         Ok(summary_str) => {

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -1,0 +1,29 @@
+use std::process::exit;
+
+
+pub fn summary(now: &DateTime<Local>, mut day: Day) {
+    let end_result: Result<(), &str> = day.end_day_at(&now);
+    match end_result {
+        Ok(_) => (),
+        _ => (),
+    }
+    if let Err(err_msg) = print_day_summary(day) {
+        eprintln(err_msg);
+        exit(1);
+    }
+}
+
+
+fn print_day_summary(day: Day) -> Result<(), &str> {
+    let config: Config = get_config();
+    let time_behind_s: i64 = config.minutes_behind() * 60;
+    let summary_result: Result<String, &str> = day.render_human_readable_summary(time_behind_s);
+    
+    return match summary_result {
+        Ok(summary_str) => {
+            println!(summary_str);
+            Ok(())
+        },
+        Err(err_msg) => Err(err_msg),
+    }
+}

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -155,7 +155,7 @@ pub fn summary_past(args: Vec<String>) {
         eprintln!("{}", err_msg);
         exit(1);
     }
-    let date: NaiveDate = parse_result.expect("Error should have already been handeled.");
+    let date: NaiveDate = parse_result.expect("Error should have already been handled.");
     let date_str: String = date.format("%Y-%m-%d").to_string();
     let day_result = read_day_from_date_str(&date_str);
     if let Err(_) = day_result {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,1 +1,2 @@
 pub mod core;
+pub mod day_summaries;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,10 @@ use crate::commands::core::{
     add_summary_to_today,
     view_config,
     edit_config,
-    summary,
 };
-use crate::utils::file_io::{create_base_dir_if_not_exists};
-use crate::utils::config::{create_default_config_if_not_exists};
+use crate::commands::day_summaries::summary;
+use crate::utils::file_io::create_base_dir_if_not_exists;
+use crate::utils::config::create_default_config_if_not_exists;
 
 const VERSION: &str = "2.4.0";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,14 +22,14 @@ use crate::commands::core::{
     view_config,
     edit_config,
 };
-use crate::commands::day_summaries::summary;
+use crate::commands::day_summaries::{summary, summary_past, summarise_week, summarise_days};
 use crate::utils::file_io::create_base_dir_if_not_exists;
 use crate::utils::config::create_default_config_if_not_exists;
 
 const VERSION: &str = "2.4.0";
 
 
-#[derive(PartialEq)]
+#[derive(PartialEq,Clone)]
 enum SubCommand {
     In(Vec<String>),
     Out(Vec<String>),
@@ -37,6 +37,9 @@ enum SubCommand {
     Pause(Vec<String>),
     Resume(Vec<String>),
     Summary(Vec<String>),
+    SummaryPast(Vec<String>),
+    SummariseWeek(Vec<String>),
+    SummariseDays(Vec<String>),
     View(Vec<String>),
     ViewPast(Vec<String>),
     Edit(Vec<String>),
@@ -52,13 +55,16 @@ enum SubCommand {
 
 impl SubCommand {
     fn from_string(name: &String, other_args: Vec<String>) -> Self {
-        return match name.to_owned().trim() {
+        return match name.to_owned().to_lowercase().trim() {
             "in" => Self::In(other_args),
             "out" => Self::Out(other_args),
             "back-in" => Self::BackIn(other_args),
             "pause" => Self::Pause(other_args),
             "resume" => Self::Resume(other_args),
             "summary" => Self::Summary(other_args),
+            "summary-past" => Self::SummaryPast(other_args),
+            "summarise-week" => Self::SummariseWeek(other_args),
+            "summarise-days" => Self::SummariseDays(other_args),
             "view" => Self::View(other_args),
             "view-past" => Self::ViewPast(other_args),
             "edit" => Self::Edit(other_args),
@@ -72,11 +78,37 @@ impl SubCommand {
             other => Self::Invalid(other.to_string()),
         }
     }
+    
+    fn to_string(self) -> String {
+        return match self {
+            Self::In(_) => "in",
+            Self::Out(_) => "out",
+            Self::BackIn(_) => "back-in",
+            Self::Pause(_) => "pause",
+            Self::Resume(_) => "resume",
+            Self::Summary(_) => "summary",
+            Self::SummaryPast(_) => "summary-past",
+            Self::SummariseWeek(_) => "summarise-week",
+            Self::SummariseDays(_) => "summarise-days",
+            Self::View(_) => "view",
+            Self::ViewPast(_) => "view-past",
+            Self::Edit(_) => "edit",
+            Self::Task(_) => "task",
+            Self::Note(_) => "note",
+            Self::EditConfig(_) => "edit-config",
+            Self::ViewConfig(_) => "view-config",
+            Self::AddSummary(_) => "add-summary",
+            Self::UpdateTask(_) => "update-task",
+            Self::Version(_) => "version",
+            Self::Invalid(_) => "invalid",
+        }.to_string();
+    }
 
     fn get_allowed_strings() -> Vec<String> {
         return Vec::from(
             [
-                "in", "out", "back-in", "pause", "resume", "summary", "view", "view-past", "edit",
+                "in", "out", "back-in", "pause", "resume", "summary", "summary-past",
+                "summarise-week", "summarise-days", "view", "view-past", "edit",
                 "task", "note", "edit-config", "add-summary", "update-task",
                 "version", "-v", "--version"
             ].map(|x: &str| x.to_string())
@@ -110,45 +142,44 @@ fn setup() {
 }
 
 fn run_command(command: SubCommand, now: DateTime<Local>) {
-    if let SubCommand::In(other_args) = command {
-        punch_in(&now, other_args);
+    let mut processed: bool = true;
+    match command.clone() {
+        SubCommand::Version(_) => println!("Current punch-card version: {}", VERSION),
+        SubCommand::Invalid(original) => handle_invalid_cmd(&original),
+        SubCommand::In(other_args) => punch_in(&now, other_args),
+        SubCommand::ViewPast(other_args) => view_past(other_args),
+        SubCommand::SummaryPast(other_args) => summary_past(other_args),
+        SubCommand::EditConfig(_) => edit_config(),
+        SubCommand::ViewConfig(_) => view_config(),
+        SubCommand::SummariseWeek(other_args) => summarise_week(other_args),
+        SubCommand::SummariseDays(other_args) => summarise_days(other_args),
+        _ => {processed = false},
     }
-    else if let SubCommand::ViewPast(other_args) = command {
-        view_past(other_args);
+    if processed {
+        exit(0);
     }
-    else if let SubCommand::Version(_other_args) = command {
-        println!("Current punch-card version: {}", VERSION);
-    }
-    else if let SubCommand::Invalid(original) = command {
-        handle_invalid_cmd(&original);
-    }
-    else {
-        let possible_day: Result<Day, String> = get_current_day(&now);
-        if let Err(msg) = possible_day {
-            eprintln!("{}", msg);
-            exit(1);
-        }
-        let day: Day = possible_day.unwrap();
 
-        match command {
-            SubCommand::Out(_) => punch_out(&now, day),
-            SubCommand::BackIn(other_args) => punch_back_in(&now, other_args, day),
-            SubCommand::Pause(other_args) => take_break(&now, other_args, day),
-            SubCommand::Resume(other_args) => resume(&now, other_args, day),
-            SubCommand::Summary(_) => summary(&now, day),
-            SubCommand::View(_) => view_day(day),
-            SubCommand::Edit(_) => edit_day(day),
-            SubCommand::EditConfig(_) => edit_config(),
-            SubCommand::ViewConfig(_) => view_config(),
-            SubCommand::Task(other_args) => switch_to_new_task(&now, day, other_args),
-            SubCommand::Note(other_args) => add_note_to_today(&now, day, other_args),
-            SubCommand::AddSummary(other_args) => add_summary_to_today(day, other_args),
-            SubCommand::UpdateTask(other_args) => update_current_task_name(&now, day, other_args),
-            SubCommand::Version(_) => unreachable!("`punch version/--version/-v` commands should already be processed."),
-            SubCommand::In(_) => unreachable!("'punch in' commands shouldn't be being processed"),
-            SubCommand::Invalid(_) => unreachable!("Invalid commands shouldn't be being processed here"),
-            SubCommand::ViewPast(_) => unreachable!("'punch view-past' commands shouldn't be processed here."),
-        }
+    let possible_day: Result<Day, String> = get_current_day(&now);
+    if let Err(msg) = possible_day {
+        eprintln!("{}", msg);
+        exit(1);
+    }
+    let day: Day = possible_day.unwrap();
+
+    match command {
+        SubCommand::Out(_) => punch_out(&now, day),
+        SubCommand::BackIn(other_args) => punch_back_in(&now, other_args, day),
+        SubCommand::Pause(other_args) => take_break(&now, other_args, day),
+        SubCommand::Resume(other_args) => resume(&now, other_args, day),
+        SubCommand::Summary(_) => summary(&now, day),
+        SubCommand::View(_) => view_day(day),
+        SubCommand::Edit(_) => edit_day(day),
+        SubCommand::Task(other_args) => switch_to_new_task(&now, day, other_args),
+        SubCommand::Note(other_args) => add_note_to_today(&now, day, other_args),
+        SubCommand::AddSummary(other_args) => add_summary_to_today(day, other_args),
+        SubCommand::UpdateTask(other_args) => update_current_task_name(&now, day, other_args),
+        SubCommand::Version(_) => unreachable!("`punch version/--version/-v` commands should already be processed."),
+        _ => unreachable!("'punch {}' commands shouldn't be processed here.", command.to_string()),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use crate::commands::core::{
     take_break,
     resume,
     view_day,
+    view_past,
     edit_day,
     switch_to_new_task,
     update_current_task_name,
@@ -37,6 +38,7 @@ enum SubCommand {
     Resume(Vec<String>),
     Summary(Vec<String>),
     View(Vec<String>),
+    ViewPast(Vec<String>),
     Edit(Vec<String>),
     Task(Vec<String>),
     Note(Vec<String>),
@@ -58,6 +60,7 @@ impl SubCommand {
             "resume" => Self::Resume(other_args),
             "summary" => Self::Summary(other_args),
             "view" => Self::View(other_args),
+            "view-past" => Self::ViewPast(other_args),
             "edit" => Self::Edit(other_args),
             "task" => Self::Task(other_args),
             "note" => Self::Note(other_args),
@@ -73,7 +76,7 @@ impl SubCommand {
     fn get_allowed_strings() -> Vec<String> {
         return Vec::from(
             [
-                "in", "out", "back-in", "pause", "resume", "summary", "view", "edit",
+                "in", "out", "back-in", "pause", "resume", "summary", "view", "view-past", "edit",
                 "task", "note", "edit-config", "add-summary", "update-task",
                 "version", "-v", "--version"
             ].map(|x: &str| x.to_string())
@@ -110,6 +113,9 @@ fn run_command(command: SubCommand, now: DateTime<Local>) {
     if let SubCommand::In(other_args) = command {
         punch_in(&now, other_args);
     }
+    else if let SubCommand::ViewPast(other_args) = command {
+        view_past(other_args);
+    }
     else if let SubCommand::Version(_other_args) = command {
         println!("Current punch-card version: {}", VERSION);
     }
@@ -141,6 +147,7 @@ fn run_command(command: SubCommand, now: DateTime<Local>) {
             SubCommand::Version(_) => unreachable!("`punch version/--version/-v` commands should already be processed."),
             SubCommand::In(_) => unreachable!("'punch in' commands shouldn't be being processed"),
             SubCommand::Invalid(_) => unreachable!("Invalid commands shouldn't be being processed here"),
+            SubCommand::ViewPast(_) => unreachable!("'punch view-past' commands shouldn't be processed here."),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use crate::commands::core::{
 use crate::utils::file_io::{create_base_dir_if_not_exists};
 use crate::utils::config::{create_default_config_if_not_exists};
 
-const VERSION: &str = "2.3.0";
+const VERSION: &str = "2.4.0";
 
 
 #[derive(PartialEq)]

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -87,30 +87,36 @@ impl AggregateDay {
     }
 
     pub fn render_human_readable_summary(&self, include_overall_time_behind: bool) -> Result<String, &str> {
-        let full_message: String = format!("Num days summarised: {}", self.num_days);
-        full_message += &format!(
+        let summary_str: String = format!("Num days summarised: {}", self.num_days);
+        summary_str += &format!(
             "\nTotal work time (including breaks): {}", render_seconds_human_readable(time_done_secs));
-        full_message += &format!(
+        summary_str += &format!(
             "\nTotal time working (excluding breaks): {}", render_seconds_human_readable(self.get_total_time_done()));
-        full_message += &format!(
+        summary_str += &format!(
             "\nTotal time spent on break: {}", render_seconds_human_readable(self.total_break_time));
-        full_message += &format!("\nTotal breaks: {}", self.total_breaks);
-        full_message += &format!(
-            "\nTime behind over period: {}", render_seconds_human_readable(self.get_time_behind_over_period()), 
-        );
-        full_message += &format!(
+        summary_str += "\n";
+        
+        summary_str += &format!(
             "\nTotal task blocks (including breaks): {}", self.get_total_blocks());
-        full_message += &format!(
+        summary_str += &format!(
             "\nTotal task blocks (excluding breaks): {}", self.get_total_non_break_blocks());
-        full_message += &"\nTask times, blocks:";
+        summary_str += &format!("\nTotal breaks: {}", self.total_breaks);
+        summary_str += "\n";
+        summary_str += &"\nTask times, blocks:";
         for (task_name, (time, blocks)) in self.tasks.into_iter() {
             tasks_summary += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(time), blocks);
         }
+        summary_str += "\n";
+
+        summary_str += &format!("\nTime to do over period: {}", render_seconds_human_readable(self.total_time_to_do));
+        summary_str += &format!(
+            "\nTime behind over period: {}", render_seconds_human_readable(self.get_time_behind_over_period()), 
+        );
         if include_overall_time_behind {
-            full_message += &format!(
+            summary_str += &format!(
                 "\nTime behind overall: {}", render_seconds_human_readable(self.get_time_behind_overall()), 
             );
         }
-        return Ok(full_message);
+        return Ok(summary_str);
     }
 }

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -1,25 +1,7 @@
-use std::collections::{HashMap,HashSet};
-use chrono::prelude::{DateTime, Local};
-use chrono::Duration;
-use serde::{Serialize, Deserialize};
+use std::collections::HashMap;
 
-use crate::units::components::TimeBlock;
-use crate::units::interval::{Dt,Interval, DATE_FMT, DATETIME_FMT};
-use crate::units::components::Day;
+use crate::units::day::Day;
 use crate::utils::misc::render_seconds_human_readable;
-
-use crate::utils::file_io::{
-    create_dir_if_not_exists,
-    expand_path, 
-    read_file,
-    write_file,
-    FromString,
-    SafeFileEdit,
-    ToFile, 
-    BASE_DIR};
-use crate::utils::work_summary::WorkSummary;
-
-pub const DAILY_DIR: &str = "days/";
 
 
 #[derive(Debug,Clone)]
@@ -34,7 +16,7 @@ pub struct AggregateDay {
 }
 
 impl AggregateDay {
-    pub fn new(starting_time_behind: u64) -> Self {
+    pub fn new(starting_time_behind: i64) -> Self {
         return Self {
             total_time: 0,
             total_break_time: 0,
@@ -42,7 +24,7 @@ impl AggregateDay {
             total_time_to_do: 0,
             num_days: 0,
             task_totals: HashMap::new(),
-            starting_time_behind: staring_time_behind
+            starting_time_behind: starting_time_behind
         };
     }
 
@@ -50,9 +32,9 @@ impl AggregateDay {
         if !day.has_ended() {
             return Err("Can't aggregate a day that hasn't ended!");
         }
-        self.total_time += day.get_day_length_secs();
-        self.total_break_time += day.get_total_break_time_secs();
-        self.total_breaks += day.get_total_timeblocks();
+        self.total_time += day.get_day_length_secs().expect("Day has ended so day length should be known.") as u64;
+        self.total_break_time += day.get_total_break_time_secs().expect("Day has ended so day length should be known.") as u64;
+        self.num_breaks += day.get_total_timeblocks();
         self.total_time_to_do += day.get_time_to_do();
         self.num_days += 1;
 
@@ -61,54 +43,54 @@ impl AggregateDay {
             let (time, blocks) = task_summaries.get(&task_name).unwrap();
             let (curr_time, curr_blocks) = self.task_totals.entry(task_name).or_insert((0, 0));
 
-            self.task_totals.insert(task_name, (curr_time + time, curr_blocks + blocks));
+            self.task_totals.insert(task_name, (*curr_time + (*time as u64), *curr_blocks + blocks));
         }
         return Ok(());
     }
 
     pub fn get_total_time_done(&self) -> u64 {
-        return self.total_time - self.total_breaks;
+        return self.total_time - self.num_breaks;
     }
 
     pub fn get_time_behind_over_period(&self) -> i64 {
-        return self.time_to_do - self.get_total_time_done();
+        return (self.total_time_to_do as i64) - (self.get_total_time_done() as i64);
     }
 
     pub fn get_time_behind_overall(&self) -> i64 {
-        return self.get_time_behind_over_period() + self.starting_time_behind();
+        return self.get_time_behind_over_period() + self.starting_time_behind;
     }
 
     pub fn get_total_blocks(&self) -> u64 {
-        return self.tasks.clone().into_iter().map(|x, (y, z)| z).sum();
+        return self.task_totals.clone().into_iter().map(|(_x, (_y, z))| z).sum();
     }
 
     pub fn get_total_non_break_blocks(&self) -> u64 {
-        return self.get_total_blocks() - self.total_breaks;
+        return self.get_total_blocks() - self.num_breaks;
     }
 
     pub fn render_human_readable_summary(&self, include_overall_time_behind: bool) -> Result<String, &str> {
         let summary_str: String = format!("Num days summarised: {}", self.num_days);
         summary_str += &format!(
-            "\nTotal work time (including breaks): {}", render_seconds_human_readable(time_done_secs));
+            "\nTotal work time (including breaks): {}", render_seconds_human_readable(self.total_time as i64));
         summary_str += &format!(
-            "\nTotal time working (excluding breaks): {}", render_seconds_human_readable(self.get_total_time_done()));
+            "\nTotal time working (excluding breaks): {}", render_seconds_human_readable(self.get_total_time_done() as i64));
         summary_str += &format!(
-            "\nTotal time spent on break: {}", render_seconds_human_readable(self.total_break_time));
+            "\nTotal time spent on break: {}", render_seconds_human_readable(self.total_break_time as i64));
         summary_str += "\n";
         
         summary_str += &format!(
             "\nTotal task blocks (including breaks): {}", self.get_total_blocks());
         summary_str += &format!(
             "\nTotal task blocks (excluding breaks): {}", self.get_total_non_break_blocks());
-        summary_str += &format!("\nTotal breaks: {}", self.total_breaks);
+        summary_str += &format!("\nTotal breaks: {}", self.num_breaks);
         summary_str += "\n";
         summary_str += &"\nTask times, blocks:";
-        for (task_name, (time, blocks)) in self.tasks.into_iter() {
-            tasks_summary += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(time), blocks);
+        for (task_name, (time, blocks)) in self.task_totals.into_iter() {
+            summary_str += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(time as i64), blocks);
         }
         summary_str += "\n";
 
-        summary_str += &format!("\nTime to do over period: {}", render_seconds_human_readable(self.total_time_to_do));
+        summary_str += &format!("\nTime to do over period: {}", render_seconds_human_readable(self.total_time_to_do as i64));
         summary_str += &format!(
             "\nTime behind over period: {}", render_seconds_human_readable(self.get_time_behind_over_period()), 
         );

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -34,7 +34,7 @@ impl AggregateDay {
         }
         self.total_time += day.get_day_length_secs().expect("Day has ended so day length should be known.") as u64;
         self.total_break_time += day.get_total_break_time_secs().expect("Day has ended so day length should be known.") as u64;
-        self.num_breaks += day.get_total_timeblocks();
+        self.num_breaks += day.get_number_of_breaks();
         self.total_time_to_do += day.get_time_to_do();
         self.num_days += 1;
 
@@ -50,7 +50,7 @@ impl AggregateDay {
     }
 
     pub fn get_total_time_done(&self) -> u64 {
-        return self.total_time - self.num_breaks;
+        return self.total_time - self.total_break_time;
     }
 
     pub fn get_time_behind_over_period(&self) -> i64 {

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -86,7 +86,7 @@ impl AggregateDay {
         return self.get_total_blocks() - self.total_breaks;
     }
 
-    pub fn render_human_readable_summary(&self, include_overall_time_behind: bool) -> String {
+    pub fn render_human_readable_summary(&self, include_overall_time_behind: bool) -> Result<String, &str> {
         let full_message: String = format!("Num days summarised: {}", self.num_days);
         full_message += &format!(
             "\nTotal work time (including breaks): {}", render_seconds_human_readable(time_done_secs));
@@ -111,6 +111,6 @@ impl AggregateDay {
                 "\nTime behind overall: {}", render_seconds_human_readable(self.get_time_behind_overall()), 
             );
         }
-        return full_message;
+        return Ok(full_message);
     }
 }

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -6,6 +6,7 @@ use serde::{Serialize, Deserialize};
 use crate::units::components::TimeBlock;
 use crate::units::interval::{Dt,Interval, DATE_FMT, DATETIME_FMT};
 use crate::units::components::Day;
+use crate::utils::misc::render_seconds_human_readable;
 
 use crate::utils::file_io::{
     create_dir_if_not_exists,
@@ -112,8 +113,4 @@ impl AggregateDay {
         }
         return full_message;
     }
-}
-
-pub fn render_seconds_human_readable(secs: i64) -> String {
-    return format!("{} m {} s", secs / 60, secs % 60);
 }

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -1,0 +1,127 @@
+use std::collections::{HashMap,HashSet};
+use chrono::prelude::{DateTime, Local};
+use chrono::Duration;
+use serde::{Serialize, Deserialize};
+
+use crate::units::components::TimeBlock;
+use crate::units::interval::{Dt,Interval, DATE_FMT, DATETIME_FMT};
+use crate::units::components::Day;
+
+use crate::utils::file_io::{
+    create_dir_if_not_exists,
+    expand_path, 
+    read_file,
+    write_file,
+    FromString,
+    SafeFileEdit,
+    ToFile, 
+    BASE_DIR};
+use crate::utils::work_summary::WorkSummary;
+
+pub const DAILY_DIR: &str = "days/";
+
+
+#[derive(Debug,Clone)]
+pub struct AggregateDay {
+    pub total_time: u64,
+    pub total_break_time: u64,
+    pub num_breaks: u64,
+    pub total_time_to_do: u64,
+    pub num_days: u64,
+    task_totals: HashMap<String,(u64, u64)>,
+    pub starting_time_behind: i64,
+}
+
+impl AggregateDay {
+    pub fn new(starting_time_behind: u64) -> Self {
+        return Self {
+            total_time: 0,
+            total_break_time: 0,
+            num_breaks: 0,
+            total_time_to_do: 0,
+            num_days: 0,
+            task_totals: HashMap::new(),
+            starting_time_behind: staring_time_behind
+        };
+    }
+
+    pub fn add_day(&mut self, day: Day) -> Result<(), &str> {
+        if !day.has_ended() {
+            return Err("Can't aggregate a day that hasn't ended!");
+        }
+        self.total_time += day.get_day_length_secs();
+        self.total_break_time += day.get_total_break_time_secs();
+        self.total_breaks += day.get_total_timeblocks();
+        self.total_time_to_do += day.get_time_to_do();
+        self.num_days += 1;
+
+        let task_summaries: HashMap<String, (i64, u64)> = day.get_task_times_secs_and_num_blocks();        
+        for task_name in day.get_tasks_in_chronological_order() {
+            let (time, blocks) = task_summaries.get(&task_name).unwrap();
+            let (curr_time, curr_blocks) = self.task_totals.entry(task_name).or_insert((0, 0));
+
+            self.task_totals.insert(task_name, (curr_time + time, curr_blocks + blocks));
+        }
+        return Ok(());
+    }
+
+    pub fn get_total_time_done(&self) -> u64 {
+        return self.total_time - self.total_breaks;
+    }
+
+    pub fn get_time_behind_over_period(&self) -> i64 {
+        return self.time_to_do - self.get_total_time_done();
+    }
+
+    pub fn get_time_behind_overall(&self) -> i64 {
+        return self.get_time_behind_over_period() + self.starting_time_behind();
+    }
+
+    pub fn get_total_blocks(&self) -> u64 {
+        return self.tasks.clone().into_iter().map(|x, (y, z)| z).sum();
+    }
+
+    pub fn get_total_non_break_blocks(&self) -> u64 {
+        return self.get_total_blocks() - self.total_breaks;
+    }
+
+    pub fn render_human_readable_summary(&self, include_overall_time_behind: bool) -> String {
+        let num_days_str: String = format!("Num days summarised: {}", self.num_days);
+        let total_time_str: String = format!(
+            "Total work time (including breaks): {}", render_seconds_human_readable(time_done_secs));
+        let total_time_done_str: String = format!(
+            "Total time working (excluding breaks): {}", render_seconds_human_readable(self.get_total_time_done()));
+        let total_break_time_str: String = format!(
+            "Total time spent on break: {}", render_seconds_human_readable(self.total_break_time));
+        let total_breaks_str: String = format!("Total breaks: {}", self.total_breaks);
+        let time_behind_str: String = format!(
+            "Time behind over period: {}", render_seconds_human_readable(self.get_time_behind_over_period()), 
+        );
+        let main_summary = format!(
+            "{}\n{}\n{}\n{}\n{}\n{}", 
+            num_days_str, total_time_str, total_time_done_str, total_break_time_str, total_breaks_str, time_behind_str
+        );
+        let total_blocks_str: String = format!(
+            "Total task blocks (including breaks): {}", self.get_total_blocks());
+        let total_non_break_blocks_str: String = format!(
+            "Total task blocks (excluding breaks): {}", self.get_total_non_break_blocks());
+        let tasks_summary: String = format!(
+            "{}\n{}\nTask times, blocks:", total_blocks_str, total_non_break_blocks_str
+        );
+        for (task_name, (time, blocks)) in self.tasks.into_iter() {
+            tasks_summary += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(time), blocks);
+        }
+
+        let full_message: String = format!("{}\n{}", main_summary, tasks_summary);
+        if include_overall_time_behind {
+            full_message += &format!(
+                "\nTime behind overall: {}", render_seconds_human_readable(self.get_time_behind_overall()), 
+            );
+        }
+        return full_message;
+    }
+}
+
+pub fn render_seconds_human_readable(secs: i64) -> String {
+    return format!("{} m {} s", secs / 60, secs % 60);
+}

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -69,7 +69,7 @@ impl AggregateDay {
         return self.get_total_blocks() - self.num_breaks;
     }
 
-    pub fn render_human_readable_summary(&self, include_overall_time_behind: bool) -> Result<String, &str> {
+    pub fn render_human_readable_summary(&self, include_overall_time_behind: bool) -> Result<String, String> {
         let mut summary_str: String = format!("Num days summarised: {}", self.num_days);
         summary_str += &format!(
             "\nTotal work time (including breaks): {}", render_seconds_human_readable(self.total_time as i64));

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -86,33 +86,25 @@ impl AggregateDay {
     }
 
     pub fn render_human_readable_summary(&self, include_overall_time_behind: bool) -> String {
-        let num_days_str: String = format!("Num days summarised: {}", self.num_days);
-        let total_time_str: String = format!(
-            "Total work time (including breaks): {}", render_seconds_human_readable(time_done_secs));
-        let total_time_done_str: String = format!(
-            "Total time working (excluding breaks): {}", render_seconds_human_readable(self.get_total_time_done()));
-        let total_break_time_str: String = format!(
-            "Total time spent on break: {}", render_seconds_human_readable(self.total_break_time));
-        let total_breaks_str: String = format!("Total breaks: {}", self.total_breaks);
-        let time_behind_str: String = format!(
-            "Time behind over period: {}", render_seconds_human_readable(self.get_time_behind_over_period()), 
+        let full_message: String = format!("Num days summarised: {}", self.num_days);
+        full_message += &format!(
+            "\nTotal work time (including breaks): {}", render_seconds_human_readable(time_done_secs));
+        full_message += &format!(
+            "\nTotal time working (excluding breaks): {}", render_seconds_human_readable(self.get_total_time_done()));
+        full_message += &format!(
+            "\nTotal time spent on break: {}", render_seconds_human_readable(self.total_break_time));
+        full_message += &format!("\nTotal breaks: {}", self.total_breaks);
+        full_message += &format!(
+            "\nTime behind over period: {}", render_seconds_human_readable(self.get_time_behind_over_period()), 
         );
-        let main_summary = format!(
-            "{}\n{}\n{}\n{}\n{}\n{}", 
-            num_days_str, total_time_str, total_time_done_str, total_break_time_str, total_breaks_str, time_behind_str
-        );
-        let total_blocks_str: String = format!(
-            "Total task blocks (including breaks): {}", self.get_total_blocks());
-        let total_non_break_blocks_str: String = format!(
-            "Total task blocks (excluding breaks): {}", self.get_total_non_break_blocks());
-        let tasks_summary: String = format!(
-            "{}\n{}\nTask times, blocks:", total_blocks_str, total_non_break_blocks_str
-        );
+        full_message += &format!(
+            "\nTotal task blocks (including breaks): {}", self.get_total_blocks());
+        full_message += &format!(
+            "\nTotal task blocks (excluding breaks): {}", self.get_total_non_break_blocks());
+        full_message += &"\nTask times, blocks:";
         for (task_name, (time, blocks)) in self.tasks.into_iter() {
             tasks_summary += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(time), blocks);
         }
-
-        let full_message: String = format!("{}\n{}", main_summary, tasks_summary);
         if include_overall_time_behind {
             full_message += &format!(
                 "\nTime behind overall: {}", render_seconds_human_readable(self.get_time_behind_overall()), 

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -34,7 +34,7 @@ impl AggregateDay {
         }
         self.total_time += day.get_day_length_secs().expect("Day has ended so day length should be known.") as u64;
         self.total_break_time += day.get_total_break_time_secs().expect("Day has ended so day length should be known.") as u64;
-        self.num_breaks += day.get_number_of_breaks();
+        self.num_breaks += day.get_number_of_breaks().expect("Day has ended so day length should be known.");
         self.total_time_to_do += day.get_time_to_do();
         self.num_days += 1;
 

--- a/src/units/components.rs
+++ b/src/units/components.rs
@@ -87,6 +87,7 @@ impl TimeBlock {
         return self.interval.get_length_secs();
     }
 
+    #[allow(dead_code)]
     pub fn get_length_mins(&self) -> Option<i64> {
         return self.interval.get_length_mins();
     }

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -250,6 +250,13 @@ impl Day {
         };
     }
 
+    pub fn get_number_of_breaks(&self) -> Option<u64> {
+        return match self.on_break {
+            true => None,
+            false => self.breaks.iter().map(|x: &usize| self.timeblocks[*x].get_length_secs()).count(),
+        };
+    }
+
     pub fn get_time_done_secs(&self) -> Option<i64> {
         return match (self.get_day_length_secs(), self.get_total_break_time_secs()) {
             (Some(day), Some(breaks)) => Some(day - breaks),
@@ -307,24 +314,33 @@ impl Day {
         let break_time: i64 = self.get_total_break_time_secs().expect("Day is over so we should be able to calculate total break time!");
         let task_summaries: HashMap<String, (i64, u64)> = day.get_task_times_secs_and_num_blocks();
         let total_blocks: u64 = self.get_total_timeblocks();
+        let num_breaks: u64 = self.get_number_of_breaks().unwrap();
         let total_blocks_without_breaks: u64 = self.get_total_timeblocks_without_breaks();
-    
         let time_done_secs: i64 = self.get_time_done_secs().unwrap();
+
         let summary_str: String = format!(
-            "Time done today: {}", render_seconds_human_readable(time_done_secs)
+            "Total time (from punch in to punch out): {}", render_seconds_human_readable(self.get)
         );
-        summay_str += &format!(
-            "\nTotal time spent on break: {}", render_seconds_human_readable(break_time)
+        summary_str += &format!("Time done today: {}", render_seconds_human_readable(time_done_secs));
+        summary_str += &format!(
+            "\nTime spent on break: {}", render_seconds_human_readable(break_time)
         );
-        summary_str += &format!("\n\nTotal task blocks (including breaks): {}", total_blocks);
+        summary_str += "\n";
+
+        summary_str += &format!("\nTotal task blocks (including breaks): {}", total_blocks);
         summary_str += &format!("\nTotal task blocks (excluding breaks): {}", total_blocks_without_breaks);
+        summary_str += &format!("\nNumber of breaks: {}", num_breaks);
+        summary_str += "\n";
+
         summary_str += &format!("\nLatest task: '{}'", self.get_latest_task_name());
         summary_str += &format!("\nTask times, blocks:");
         for task_name in self.get_tasks_in_chronological_order() {
             let (time, blocks) = task_summaries.get(&task_name).unwrap();
             summary_str += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(time), blocks);
         }
-        summary_str += &format!("\n\nTime to do today: {}", render_seconds_human_readable(self.time_to_do));
+        summary_str += "\n";
+
+        summary_str += &format!("\nTime to do today: {}", render_seconds_human_readable(self.time_to_do));
         summary_str += &format!("\nTime left to do today: {}", render_seconds_human_readable(time_left));
         if let Some(initial_time_behind) = initial_time_behind_opt {
             let total_time_behind: i64 = initial_time_behind + time_left;

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -321,7 +321,7 @@ impl Day {
         let total_blocks_without_breaks: u64 = self.get_total_timeblocks_without_breaks();
         let time_done_secs: i64 = self.get_time_done_secs().unwrap();
 
-        let summary_str: String = format!(
+        let mut summary_str: String = format!(
             "Total time (from punch in to punch out): {}", render_seconds_human_readable(day_length)
         );
         summary_str += &format!("Time done today: {}", render_seconds_human_readable(time_done_secs));

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -325,10 +325,14 @@ pub fn string_as_time(time_str: &String) -> DateTime<Local> {
     return start_time;
 }
 
+pub fn get_day_file_path_from_date_str(date_str: &str) -> String {
+    return expand_path(BASE_DIR) + &(DAILY_DIR.to_string()) + date_str;
+}
+
 
 pub fn get_day_file_path(now: &DateTime<Local>) -> String {
     let day_string: String = now.format(DATE_FMT).to_string();
-    return expand_path(BASE_DIR) + &(DAILY_DIR.to_string()) + &day_string;
+    return get_day_file_path_from_date_str(&day_string);
 }
 
 
@@ -338,14 +342,21 @@ pub fn write_day(day: &Day) {
 }
 
 
-pub fn read_day(now: &DateTime<Local>) -> Result<Day, std::io::Error> {
-    let path: &String = &get_day_file_path(&now);
+pub fn read_day_from_date_str(date_str: &str) -> Result<Day, std::io::Error> {
+    let path: &String = &get_day_file_path_from_date_str(date_str);
     let read_result: Result<String, std::io::Error> = read_file(path);
     return match read_result {
         Ok(string) => Ok(Day::from_string(&string)),
         Err(err) => Err(err),
     };
 }
+
+
+pub fn read_day(now: &DateTime<Local>) -> Result<Day, std::io::Error> {
+    let day_string: String = now.format(DATE_FMT).to_string();
+    return read_day_from_date_str(&day_string);
+}
+
 
 pub fn get_current_day(now: &DateTime<Local>) -> Result<Day, String> {
     let yesterday: DateTime<Local> = *now - Duration::days(1);
@@ -359,6 +370,7 @@ pub fn get_current_day(now: &DateTime<Local>) -> Result<Day, String> {
         return Err("Can't get current day. Have you punched in?".to_string());
     }
 }
+
 
 pub fn create_daily_dir_if_not_exists() {
     let daily_dir: String = BASE_DIR.to_string() + &(DAILY_DIR.to_string());

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -278,12 +278,16 @@ impl Day {
         self.summaries.push(summary);
     }
 
+    pub fn get_total_break_timeblocks(&self) -> u64 {
+        return self.breaks.len() as u64;
+    }
+
     pub fn get_total_timeblocks(&self) -> u64 {
         return self.timeblocks.len() as u64;
     }
 
     pub fn get_total_timeblocks_without_breaks(&self) -> u64 {
-        return self.get_total_timeblocks() - (self.breaks.len() as u64);
+        return self.get_total_timeblocks() - self.get_total_break_timeblocks();
     }
 
     pub fn get_tasks_in_chronological_order(&self) -> Vec<String> {

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -325,7 +325,7 @@ impl Day {
         let mut summary_str: String = format!(
             "Total time (from punch in to punch out): {}", render_seconds_human_readable(day_length)
         );
-        summary_str += &format!("Time done today: {}", render_seconds_human_readable(time_done_secs));
+        summary_str += &format!("\nTime done today: {}", render_seconds_human_readable(time_done_secs));
         summary_str += &format!(
             "\nTime spent on break: {}", render_seconds_human_readable(break_time)
         );

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -253,7 +253,9 @@ impl Day {
     pub fn get_number_of_breaks(&self) -> Option<u64> {
         return match self.on_break {
             true => None,
-            false => self.breaks.iter().map(|x: &usize| self.timeblocks[*x].get_length_secs()).count(),
+            false => Some(
+                self.breaks.iter().map(|x: &usize| self.timeblocks[*x].get_length_secs()).count() as u64
+            ),
         };
     }
 
@@ -305,21 +307,22 @@ impl Day {
         return task_name_vec;
     }
 
-    pub fn render_human_readable_summary(&self, initial_time_behind_opt: Option<i64>) -> Result<String, &str> {
+    pub fn render_human_readable_summary(&self, initial_time_behind_opt: Option<i64>) -> Result<String, String> {
         if !self.has_ended() {
-            return Err("Can't summarise a day before it is over!")
+            return Err("Can't summarise a day before it is over!".to_string())
         }
 
+        let day_length: i64 = self.get_day_length_secs().expect("Day is over so we should be able to calculate day length!");
         let time_left: i64 = self.get_time_left_secs().expect("Day is over so we should be able to calculate time left!");
         let break_time: i64 = self.get_total_break_time_secs().expect("Day is over so we should be able to calculate total break time!");
-        let task_summaries: HashMap<String, (i64, u64)> = day.get_task_times_secs_and_num_blocks();
+        let task_summaries: HashMap<String, (i64, u64)> = self.get_task_times_secs_and_num_blocks();
         let total_blocks: u64 = self.get_total_timeblocks();
         let num_breaks: u64 = self.get_number_of_breaks().unwrap();
         let total_blocks_without_breaks: u64 = self.get_total_timeblocks_without_breaks();
         let time_done_secs: i64 = self.get_time_done_secs().unwrap();
 
         let summary_str: String = format!(
-            "Total time (from punch in to punch out): {}", render_seconds_human_readable(self.get)
+            "Total time (from punch in to punch out): {}", render_seconds_human_readable(day_length)
         );
         summary_str += &format!("Time done today: {}", render_seconds_human_readable(time_done_secs));
         summary_str += &format!(
@@ -336,11 +339,11 @@ impl Day {
         summary_str += &format!("\nTask times, blocks:");
         for task_name in self.get_tasks_in_chronological_order() {
             let (time, blocks) = task_summaries.get(&task_name).unwrap();
-            summary_str += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(time), blocks);
+            summary_str += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(*time), blocks);
         }
         summary_str += "\n";
 
-        summary_str += &format!("\nTime to do today: {}", render_seconds_human_readable(self.time_to_do));
+        summary_str += &format!("\nTime to do today: {}", render_seconds_human_readable(self.time_to_do as i64));
         summary_str += &format!("\nTime left to do today: {}", render_seconds_human_readable(time_left));
         if let Some(initial_time_behind) = initial_time_behind_opt {
             let total_time_behind: i64 = initial_time_behind + time_left;

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -310,7 +310,7 @@ impl Day {
 
     pub fn render_human_readable_summary(&self, initial_time_behind_opt: Option<i64>) -> Result<String, String> {
         if !self.has_ended() {
-            return Err("Can't summarise a day before it is over!".to_string())
+            return Err("Can't summarise a day before it has ended!".to_string())
         }
 
         let day_length: i64 = self.get_day_length_secs().expect("Day is over so we should be able to calculate day length!");

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -208,6 +208,7 @@ impl Day {
         return self.overall_interval.get_length_mins() 
     }
 
+    #[allow(dead_code)]
     pub fn get_task_times_secs(&self) -> HashMap<String, i64> {
         return HashMap::from_iter(
             self.tasks.clone().into_iter().map(

--- a/src/units/mod.rs
+++ b/src/units/mod.rs
@@ -1,3 +1,4 @@
+pub mod aggregate_day;
 pub mod day;
 pub mod interval;
 pub mod components;

--- a/src/utils/dates_and_times.rs
+++ b/src/utils/dates_and_times.rs
@@ -1,0 +1,29 @@
+use chrono::{DateTime, Duration, Local, NaiveDate};
+use std::mem;
+
+pub struct DateRange(pub NaiveDate, pub NaiveDate);
+
+impl Iterator for DateRange {
+    type Item = NaiveDate;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0 <= self.1 {
+            let next = self.0 + Duration::days(1);
+            Some(mem::replace(&mut self.0, next))
+        } else {
+            None
+        }
+    }
+}
+
+
+pub fn get_local_now() -> DateTime<Local> {
+    return Local::now();
+}
+
+pub fn convert_date_to_date_str(date: NaiveDate) -> String {
+    return date.format("%Y-%m-%d").to_string();
+}
+
+pub fn get_todays_date_str() -> String {
+    return convert_date_to_date_str(get_local_now().date_naive());
+}

--- a/src/utils/dates_and_times.rs
+++ b/src/utils/dates_and_times.rs
@@ -24,6 +24,7 @@ pub fn convert_date_to_date_str(date: NaiveDate) -> String {
     return date.format("%Y-%m-%d").to_string();
 }
 
+#[allow(dead_code)]
 pub fn get_todays_date_str() -> String {
     return convert_date_to_date_str(get_local_now().date_naive());
 }

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -1,0 +1,3 @@
+pub fn render_seconds_human_readable(secs: i64) -> String {
+    return format!("{} m {} s", secs / 60, secs % 60);
+}

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -20,7 +20,9 @@ pub fn convert_input_to_seconds(input_str: &str) -> Result<i64, String> {
     if let Ok(secs) = parse_result {
         return Ok(secs);
     }
-    let err_msg: String = format!("Malformed number of seconds. Should be of the form: [zh][ym]xs. Got {}", input_str);
+    let err_msg: String = format!(
+        "Malformed number of seconds. Should be either an integer or of the form: [zh][ym]xs. Got {}", input_str
+    );
     let mut secs: i64 = 0;
     let mut rest: String = input_str.to_lowercase().clone();
     let steps: Vec<(&str, i64)> = vec![("h", 60 * 60), ("m", 60), ("s", 60)];

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -8,15 +8,15 @@ pub fn render_seconds_human_readable(secs: i64) -> String {
     if abs_secs >= 60 * 60 {
         let hours: i64 = abs_secs / (60 * 60);
         let seconds_left:i64 = abs_secs % (60 * 60);
-        abs_output =  format!("{} h {}", hours, render_seconds_human_readable(sign * seconds_left));
+        abs_output =  format!("{}h {}", hours, render_seconds_human_readable(seconds_left));
     }
     else if abs_secs >= 60 {
         let minutes: i64 = abs_secs / 60;
         let seconds_left: i64 = abs_secs % 60;
-        abs_output = format!("{} m {}", minutes, render_seconds_human_readable(seconds_left));
+        abs_output = format!("{}m {}", minutes, render_seconds_human_readable(seconds_left));
     }
     else {
-        abs_output = format!("{} s", abs_secs);
+        abs_output = format!("{}s", abs_secs);
     }
     return format!("{}{}", sign_str, abs_output);
 }

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -2,12 +2,12 @@ pub fn render_seconds_human_readable(secs: i64) -> String {
     if secs >= 60 * 60 {
         let hours: i64 = secs / (60 * 60);
         let seconds_left:i64 = secs % (60 * 60);
-        return format("{} h {}", hours, render_seconds_human_readable(seconds_left));
+        return format!("{} h {}", hours, render_seconds_human_readable(seconds_left));
     }
     else if secs >= 60 {
         let minutes: i64 = secs / 60;
         let seconds_left: i64 = secs % 60;
-        return format("{} m {}", render_seconds_human_readable(seconds_left));
+        return format!("{} m {}", minutes, render_seconds_human_readable(seconds_left));
     }
     else {
         return format!("{} s", secs);

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -31,11 +31,16 @@ pub fn convert_input_to_seconds(input_str: &str) -> Result<i64, String> {
     );
     let mut secs: i64 = 0;
     let rest: String = input_str.to_lowercase().clone();
+
+    let check_regex = Regex::new(r"^(\-)?(\d+h)?(\d+m)?(\d+s)$").unwrap();
+    if !check_regex.is_match(&rest) {
+        return Err(err_msg);
+    }
+
     let units_to_secs: HashMap<&str, i64> = HashMap::from([("h", 60 * 60), ("m", 60), ("s", 1)]);
     let re = Regex::new(r"(\d+)([hms])").unwrap();
-    
+    let sign: i64 = if rest.starts_with('-') {-1} else {1};
     for (_, [amount, unit]) in re.captures_iter(&rest).map(|c| c.extract()) {
-        println!("{}, {}", amount, unit);
         let parse_result = amount.parse::<i64>();
         if let Err(_) = parse_result {
             return Err(err_msg);
@@ -44,6 +49,5 @@ pub fn convert_input_to_seconds(input_str: &str) -> Result<i64, String> {
         let multiplier_for_secs: i64 = *units_to_secs.get(unit).unwrap();
         secs += num_unit * multiplier_for_secs;
     }
-    print!("{}", secs);
-    return Ok(secs);
+    return Ok(sign * secs);
 }

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -14,3 +14,31 @@ pub fn render_seconds_human_readable(secs: i64) -> String {
     }
 
 }
+
+pub fn convert_input_to_seconds(input_str: &str) -> Result<i64, String> {
+    let parse_result: Result<i64, std::num::ParseIntError> = input_str.parse::<i64>();
+    if let Ok(secs) = parse_result {
+        return Ok(secs);
+    }
+    let err_msg: String = format!("Malformed number of seconds. Should be of the form: [zh][ym]xs. Got {}", input_str);
+    let mut secs: i64 = 0;
+    let mut rest: String = input_str.to_lowercase().clone();
+    let steps: Vec<(&str, i64)> = vec![("h", 60 * 60), ("m", 60), ("s", 60)];
+    for (sep, secs_per) in steps {
+        let this_split: Vec<&str> = rest.split(sep).collect();
+        match this_split.len() {
+            0 => unreachable!("This shouldn't happen"),
+            2 => {
+                let parse_result = this_split[0].trim().parse::<i64>();
+                if let Err(_) = parse_result {
+                    return Err(err_msg);
+                }
+                secs += parse_result.expect(&err_msg) * secs_per;
+                rest = this_split[1].to_string();
+            },
+            1 => rest = this_split[0].to_string(),
+            _ => return Err(format!("Malformed number of seconds. Should be of the form: [zh][ym]xs. Got {}", input_str)),
+        }
+    }
+    return Ok(secs);
+}

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use regex::Regex;
+
 pub fn render_seconds_human_readable(secs: i64) -> String {
     let (sign, sign_str): (i64, &str) = if secs < 0 {(-1, "-")} else {(1, "")};
     let abs_secs: i64 = sign * secs;
@@ -27,23 +30,20 @@ pub fn convert_input_to_seconds(input_str: &str) -> Result<i64, String> {
         "Malformed number of seconds. Should be either an integer or of the form: [zh][ym]xs. Got {}", input_str
     );
     let mut secs: i64 = 0;
-    let mut rest: String = input_str.to_lowercase().clone();
-    let steps: Vec<(&str, i64)> = vec![("h", 60 * 60), ("m", 60), ("s", 60)];
-    for (sep, secs_per) in steps {
-        let this_split: Vec<&str> = rest.split(sep).collect();
-        match this_split.len() {
-            0 => unreachable!("This shouldn't happen"),
-            2 => {
-                let parse_result = this_split[0].trim().parse::<i64>();
-                if let Err(_) = parse_result {
-                    return Err(err_msg);
-                }
-                secs += parse_result.expect(&err_msg) * secs_per;
-                rest = this_split[1].to_string();
-            },
-            1 => rest = this_split[0].to_string(),
-            _ => return Err(format!("Malformed number of seconds. Should be of the form: [zh][ym]xs. Got {}", input_str)),
+    let rest: String = input_str.to_lowercase().clone();
+    let units_to_secs: HashMap<&str, i64> = HashMap::from([("h", 60 * 60), ("m", 60), ("s", 1)]);
+    let re = Regex::new(r"(\d+)([hms])").unwrap();
+    
+    for (_, [amount, unit]) in re.captures_iter(&rest).map(|c| c.extract()) {
+        println!("{}, {}", amount, unit);
+        let parse_result = amount.parse::<i64>();
+        if let Err(_) = parse_result {
+            return Err(err_msg);
         }
+        let num_unit: i64 = parse_result.unwrap();
+        let multiplier_for_secs: i64 = *units_to_secs.get(unit).unwrap();
+        secs += num_unit * multiplier_for_secs;
     }
+    print!("{}", secs);
     return Ok(secs);
 }

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -1,3 +1,16 @@
 pub fn render_seconds_human_readable(secs: i64) -> String {
-    return format!("{} m {} s", secs / 60, secs % 60);
+    if secs >= 60 * 60 {
+        let hours: i64 = secs / (60 * 60);
+        let seconds_left:i64 = secs % (60 * 60);
+        return format("{} h {}", hours, render_seconds_human_readable(seconds_left));
+    }
+    else if secs >= 60 {
+        let minutes: i64 = secs / 60;
+        let seconds_left: i64 = secs % 60;
+        return format("{} m {}", render_seconds_human_readable(seconds_left));
+    }
+    else {
+        return format!("{} s", secs);
+    }
+
 }

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -1,18 +1,21 @@
 pub fn render_seconds_human_readable(secs: i64) -> String {
-    if secs >= 60 * 60 {
-        let hours: i64 = secs / (60 * 60);
-        let seconds_left:i64 = secs % (60 * 60);
-        return format!("{} h {}", hours, render_seconds_human_readable(seconds_left));
+    let (sign, sign_str): (i64, &str) = if secs < 0 {(-1, "-")} else {(1, "")};
+    let abs_secs: i64 = sign * secs;
+    let abs_output: String;
+    if abs_secs >= 60 * 60 {
+        let hours: i64 = abs_secs / (60 * 60);
+        let seconds_left:i64 = abs_secs % (60 * 60);
+        abs_output =  format!("{} h {}", hours, render_seconds_human_readable(sign * seconds_left));
     }
-    else if secs >= 60 {
-        let minutes: i64 = secs / 60;
-        let seconds_left: i64 = secs % 60;
-        return format!("{} m {}", minutes, render_seconds_human_readable(seconds_left));
+    else if abs_secs >= 60 {
+        let minutes: i64 = abs_secs / 60;
+        let seconds_left: i64 = abs_secs % 60;
+        abs_output = format!("{} m {}", minutes, render_seconds_human_readable(seconds_left));
     }
     else {
-        return format!("{} s", secs);
+        abs_output = format!("{} s", abs_secs);
     }
-
+    return format!("{}{}", sign_str, abs_output);
 }
 
 pub fn convert_input_to_seconds(input_str: &str) -> Result<i64, String> {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod file_io;
 pub mod config;
 pub mod work_summary;
+pub mod misc;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod file_io;
 pub mod config;
+pub mod dates_and_times;
 pub mod work_summary;
 pub mod misc;


### PR DESCRIPTION
This PR adds the following new commands:
1. view-past: Allows the user to view (in the same sense as `punch view`) a day from the past. Solves #41 (or at least makes it unnecesssary).
2. summary-past: Allows the user to get the summary (in the same sense as `punch summary`) for a day in the past.
3. summarise-week: Allows the user to get a summary (in a similar sense to `punch summary`) for a week. By default, that week ends on the current day. Partially solves #61 
4. summarise-days: Allows the user to get a summary (in a similar sense to `punch summary`) for a range of dates between the given dates. Solves #61 

Also:
- `edit-config` and `view-config` now don't require punching in (#64 )
- The non-negative minutes behind has been removed from summaries since it's confusing and not particularly useful (#65 )
- The summaries of elapsed times now shows the hours as well if we have more than 60 minutes.