### PR TITLE
Let users specify an editor through config, or use fallback

### DIFF
--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -1,35 +1,37 @@
-use serde::{Serialize,Deserialize};
+use serde::{Serialize, Deserialize};
 use std::path::Path;
-use crate::utils::file_io::{expand_path,write_file,read_file,BASE_DIR, FromString, ToFile, SafeFileEdit};
+use crate::utils::file_io::{expand_path, write_file, read_file, BASE_DIR, FromString, ToFile, SafeFileEdit};
 
 pub const CONFIG_FILE: &str = "punch.cfg";
 const DEFAULT_TIME_MINS: i64 = 480;
 const DEFAULT_PUNCH_IN_TASK: &str = "Starting-up";
 const DEFAULT_BREAK_TASK: &str = "Break";
 
-#[derive(Debug,Serialize,Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
     day_in_minutes: i64,
     default_punch_in_task: String,
     default_break_task: String,
     minutes_behind: i64,
     minutes_behind_non_neg: u64,
+    editor_path: Option<String>,
 }
 
 impl Config {
     pub fn new(
-        day_length: i64, 
-        default_punch_in_task: String, 
-        default_break_task: String, 
-        minutes_behind: i64) 
-    -> Self {
+        day_length: i64,
+        default_punch_in_task: String,
+        default_break_task: String,
+        minutes_behind: i64)
+        -> Self {
         return Self {
-            day_in_minutes: day_length, 
+            day_in_minutes: day_length,
             default_punch_in_task: default_punch_in_task,
             default_break_task: default_break_task,
             minutes_behind: minutes_behind,
-            minutes_behind_non_neg: if minutes_behind < 0 {0} else {minutes_behind} as u64,
-        }
+            minutes_behind_non_neg: if minutes_behind < 0 { 0 } else { minutes_behind } as u64,
+            editor_path: Some("vim".to_string()),
+        };
     }
 
     pub fn as_string(&self) -> String {
@@ -55,11 +57,12 @@ impl Config {
     pub fn minutes_behind_non_neg(&self) -> u64 {
         return self.minutes_behind_non_neg;
     }
+    pub fn editor_path(&self) -> Option<&String> { return self.editor_path.as_ref(); }
 
     pub fn update_minutes_behind(&mut self, delta: i64) {
         let true_time_behind: i64 = self.minutes_behind() + delta;
         let non_neg_time_behind: i64 = self.minutes_behind_non_neg() as i64 + delta;
-        let new_non_neg_time_behind: u64 = if true_time_behind < 0 || non_neg_time_behind < 0 {0} else {non_neg_time_behind} as u64;
+        let new_non_neg_time_behind: u64 = if true_time_behind < 0 || non_neg_time_behind < 0 { 0 } else { non_neg_time_behind } as u64;
         self.minutes_behind = true_time_behind;
         self.minutes_behind_non_neg = new_non_neg_time_behind;
     }
@@ -86,7 +89,7 @@ impl ToFile for Config {
     }
 }
 
-impl SafeFileEdit<Config, serde_yaml::Error> for Config{}
+impl SafeFileEdit<Config, serde_yaml::Error> for Config {}
 
 pub fn write_config(path: &String, config: &Config) {
     write_file(path, config.as_string());
@@ -101,7 +104,7 @@ pub fn create_default_config_if_not_exists() {
     let config_path: String = expand_path(&(BASE_DIR.to_owned() + &(CONFIG_FILE.to_owned())));
     if !Path::new(&config_path).exists() {
         let default_config: Config = Config::new(
-            DEFAULT_TIME_MINS, 
+            DEFAULT_TIME_MINS,
             DEFAULT_PUNCH_IN_TASK.to_owned(),
             DEFAULT_BREAK_TASK.to_owned(),
             0);

--- a/src/utils/file_io.rs
+++ b/src/utils/file_io.rs
@@ -1,39 +1,42 @@
-use std::fs::{File, OpenOptions, create_dir_all, read_to_string, remove_file};
+use crate::utils::config::get_config;
+use std::env;
+use std::env::var;
+use std::fs::{create_dir_all, read_to_string, remove_file, File, OpenOptions};
 use std::io::Write;
 use std::path::Path;
-use std::env::var;
 
 pub const BASE_DIR: &str = "~/.punch-card/";
 
 pub fn write_file(path: &str, contents: String) {
     let path_str_to_write: String = expand_path(path);
-    let path_to_write: &Path = Path::new(&path_str_to_write); 
+    let path_to_write: &Path = Path::new(&path_str_to_write);
     if path_to_write.exists() {
         remove_file(path_str_to_write.clone()).expect("Should be able to delete");
     }
     let file_result: Result<File, std::io::Error> = OpenOptions::new()
-        .create(true).write(true)
+        .create(true)
+        .write(true)
         .open(path_str_to_write);
     if let Ok(mut file) = file_result {
-        file.write_all(contents.as_bytes()).expect("Couldn't write to file!");
-    }
-    else {
+        file.write_all(contents.as_bytes())
+            .expect("Couldn't write to file!");
+    } else {
         panic!("Couldn't create file {path}");
     }
 }
 
-pub fn read_file(path: &str) -> Result<String,std::io::Error> {
+pub fn read_file(path: &str) -> Result<String, std::io::Error> {
     let path_to_read = expand_path(path);
     return read_to_string(path_to_read);
 }
 
-pub fn create_dir_if_not_exists(path: &str)  {
+pub fn create_dir_if_not_exists(path: &str) {
     let dir_expanded: String = expand_path(path);
     if !Path::new(&dir_expanded).exists() {
         let expect_msg: String = format!("Unable to create directory: '{path}'");
         create_dir_all(dir_expanded).expect(&expect_msg);
     }
-} 
+}
 
 pub fn create_base_dir_if_not_exists() {
     create_dir_if_not_exists(&BASE_DIR)
@@ -42,19 +45,32 @@ pub fn create_base_dir_if_not_exists() {
 pub fn expand_path(path: &str) -> String {
     return if path.starts_with("~/") {
         var("HOME").unwrap() + &path[1..]
-    }else {path.to_string()};
+    } else {
+        path.to_string()
+    };
 }
 
+pub fn edit_file(path: &String) {
+    let config = get_config();
 
-pub fn edit_file_in_vim(path: &String) {
-    std::process::Command::new("vim")
-    .arg(path)
-    .spawn()
-    .expect("Error: Failed to run editor")
-    .wait()
-    .expect("Error: Editor returned a non-zero status");
+    let editor =
+        if let Some(vim_path) = config.editor_path() {
+            vim_path.clone()
+        }
+        // Debian/Ubuntu export an EDITOR variable
+        else if let Ok(editor) = env::var("EDITOR") {
+            editor.to_string()
+        } else {
+            "vim".to_string()
+        };
+
+    std::process::Command::new(editor)
+        .arg(path)
+        .spawn()
+        .expect("Error: Failed to run editor, you can set 'editor_path' in the config")
+        .wait()
+        .expect("Error: Editor returned a non-zero status");
 }
-
 
 pub trait FromString<T, E> {
     fn try_from_string(yaml_str: &String) -> Result<T, E>;
@@ -62,30 +78,39 @@ pub trait FromString<T, E> {
     fn from_string(yaml_str: &String) -> T;
 }
 
-pub trait ToFile  {
+pub trait ToFile {
     fn get_path(&self) -> String;
 
     fn write(&self);
 }
 
-pub trait SafeFileEdit<T:FromString<T,E> + ToFile, E>: ToFile + FromString<T, E> {
+pub trait SafeFileEdit<T: FromString<T, E> + ToFile, E>: ToFile + FromString<T, E> {
     fn safe_edit_from_file(&self) {
         let std_path: String = self.get_path();
         let temp_path: String = (&std_path).to_string() + "-temp";
-        std::process::Command::new("cp").args([&std_path, &temp_path]).output().expect("Failed to create temporary data!");
-    
+        std::process::Command::new("cp")
+            .args([&std_path, &temp_path])
+            .output()
+            .expect("Failed to create temporary data!");
+
         println!("Opening config in vim...");
-        edit_file_in_vim(&temp_path);
+        edit_file(&temp_path);
         println!("Vim closed.");
         let yaml_str: String = read_file(&temp_path).unwrap();
         let new_result: Result<T, E> = T::try_from_string(&yaml_str);
         match new_result {
             Ok(new_value) => {
-                std::process::Command::new("rm").arg(&std_path).output().expect("Failed to clean up the temporary data!");
+                std::process::Command::new("rm")
+                    .arg(&std_path)
+                    .output()
+                    .expect("Failed to clean up the temporary data!");
                 new_value.write();
-            },
+            }
             Err(_) => println!("Invalid Config created. Please try again"),
         };
-        std::process::Command::new("rm").arg(&temp_path).output().expect("Failed to clean up the temporary data!");
+        std::process::Command::new("rm")
+            .arg(&temp_path)
+            .output()
+            .expect("Failed to clean up the temporary data!");
     }
 }


### PR DESCRIPTION
This PR lets an user set an editor in the config file. 
Not every *nix has vim installed and not every user wants to (or can) use vim. 

(I run rustfmt as part of my build step so the formatting changed a bit. This is the formatting used by the larger part of the rust community. I can revert the formatting if you want and only push the changes needed for the config.) 