### PR TITLE
Bugfix@fixing issues after pr66

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 
 [dependencies]

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -51,7 +51,12 @@ fn get_default_punch_in_task() -> String {
 
 pub fn punch_out(now: &DateTime<Local>, mut day: Day) {
     if let Ok(_) = day.end_day_at(&now) {
-        println!("Punching out for the day at '{}'", &day.get_day_end_as_str().unwrap().trim());
+        println!("Punching out for the day at '{}'", &day.get_day_end_as_str().unwrap().trim());        
+        let summary_result = print_day_summary(&day, true);
+        if let Err(err_msg) = summary_result {
+            eprintln!("{}", err_msg);
+            exit(1);
+        }
         write_day(&day);
         match update_time_behind(day) {
             Ok(()) => (),
@@ -81,7 +86,7 @@ pub fn take_break(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) 
 
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day, true);
+        let summary_result = print_day_summary(&day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
@@ -118,7 +123,7 @@ pub fn resume(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) {
         write_day(&day);
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day, true);
+        let summary_result = print_day_summary(&day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
@@ -158,7 +163,7 @@ pub fn punch_back_in(now: &DateTime<Local>, other_args: Vec<String>, mut day: Da
         config.update_minutes_behind(-seconds_left_before / 60);
         update_config(config);
 
-        let summary_result = print_day_summary(day, true);
+        let summary_result = print_day_summary(&day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
@@ -193,7 +198,7 @@ pub fn switch_to_new_task(now: &DateTime<Local>, mut day: Day, other_args: Vec<S
         write_day(&day);
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day, true);
+        let summary_result = print_day_summary(&day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
@@ -304,7 +309,7 @@ pub fn update_current_task_name(now: &DateTime<Local>, mut day: Day, other_args:
         write_day(&day);
         if !day.has_ended() {day.end_day_at(&now).expect("We should be able to end the day");}
 
-        let summary_result = print_day_summary(day, true);
+        let summary_result = print_day_summary(&day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -176,7 +176,7 @@ pub fn summary_past(args: Vec<String>) {
         exit(1);
     }
     let day: Day = day_result.expect("Already handled the error case!");
-    if let Err(err_msg) = print_day_summary(day, false) {
+    if let Err(err_msg) = print_day_summary(&day, false) {
         eprintln!("{}", err_msg);
         exit(1);
     }
@@ -207,14 +207,14 @@ pub fn summary(now: &DateTime<Local>, mut day: Day) {
             },
         }
     }
-    if let Err(err_msg) = print_day_summary(day, true) {
+    if let Err(err_msg) = print_day_summary(&day, true) {
         eprintln!("{}", err_msg);
         exit(1);
     }
 }
 
 
-pub fn print_day_summary(day: Day, use_config_for_time_behind: bool) -> Result<(), String> {
+pub fn print_day_summary(day: &Day, use_config_for_time_behind: bool) -> Result<(), String> {
     let time_behind_opt: Option<i64> = match use_config_for_time_behind {
         true => {
             let config: Config = get_config();

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -197,13 +197,15 @@ fn parse_args_for_summary_past(args: Vec<String>) -> Result<NaiveDate, String> {
 }
 
 pub fn summary(now: &DateTime<Local>, mut day: Day) {
-    let end_result: Result<(), &str> = day.end_day_at(&now);
-    match end_result {
-        Ok(_) => (),
-        Err(err_msg) => {
-            eprintln!("Couldn't end day: {}", err_msg);
-            exit(1);
-        },
+    if !day.has_ended() {
+        let end_result: Result<(), &str> = day.end_day_at(&now);
+        match end_result {
+            Ok(_) => (),
+            Err(err_msg) => {
+                eprintln!("Couldn't end day: {}", err_msg);
+                exit(1);
+            },
+        }
     }
     if let Err(err_msg) = print_day_summary(day, true) {
         eprintln!("{}", err_msg);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use crate::commands::day_summaries::{summary, summary_past, summarise_week, summ
 use crate::utils::file_io::create_base_dir_if_not_exists;
 use crate::utils::config::create_default_config_if_not_exists;
 
-const VERSION: &str = "2.4.0";
+const VERSION: &str = "2.5.0";
 
 
 #[derive(PartialEq,Clone)]

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -271,6 +271,10 @@ impl Day {
         return self.time_to_do;
     }
 
+    pub fn get_time_to_do_secs(&self) -> u64 {
+        return self.time_to_do * 60;
+    }
+
     pub fn get_time_left_secs(&self) -> Option<i64> {
         return match self.get_time_done_secs() {
             Some(td) => Some((self.get_time_to_do() * 60) as i64 - td),
@@ -344,7 +348,7 @@ impl Day {
         }
         summary_str += "\n";
 
-        summary_str += &format!("\nTime to do today: {}", render_seconds_human_readable(self.time_to_do as i64));
+        summary_str += &format!("\nTime to do today: {}", render_seconds_human_readable(self.get_time_to_do_secs() as i64));
         summary_str += &format!("\nTime left to do today: {}", render_seconds_human_readable(time_left));
         if let Some(initial_time_behind) = initial_time_behind_opt {
             let total_time_behind: i64 = initial_time_behind + time_left;


### PR DESCRIPTION
Fixes some bugs/missing features from #66 .

This includes:
- #70 : Time to do was displayed incorrectly in all summaries.
- #71 : Punch summary was panicking when called after a day has ended. This has now been fixed.
- #72 : Adding a summary for punch out.