### PR TITLE
Patch@choice of display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 
 [dependencies]

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -3,14 +3,16 @@ use std::process::exit;
 
 use crate::units::day::{Day,read_day_from_date_str};
 use crate::units::aggregate_day::AggregateDay;
-use crate::utils::config::{Config, get_config};
+use crate::utils::config::{Config, get_config, SHOW_TIMES_IN_HOURS_DEFAULT};
 use crate::utils::dates_and_times::{get_local_now, DateRange};
 use crate::utils::misc::convert_input_to_seconds;
 
 pub fn summarise_week(args: Vec<String>) {
+    let config: Config = get_config();
+    let show_times_in_hours: bool = config.show_times_in_hours().unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT);
     match parse_args_for_summarise_week(args) {
         Ok((start_date, end_date, initial_time_behind_opt)) => {
-            summarise_date_range(start_date, end_date, initial_time_behind_opt)
+            summarise_date_range(start_date, end_date, initial_time_behind_opt, show_times_in_hours);
         },
         Err(msg) => {
             eprintln!("{}", msg);
@@ -46,9 +48,11 @@ fn parse_args_for_summarise_week(args: Vec<String>) -> Result<(NaiveDate, NaiveD
 }
 
 pub fn summarise_days(args: Vec<String>) {
+    let config: Config = get_config();
+    let show_times_in_hours: bool = config.show_times_in_hours().unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT);
     match parse_args_for_summarise_days(args) {
         Ok((start_date, end_date, initial_time_behind_opt)) => {
-            summarise_date_range(start_date, end_date, initial_time_behind_opt)
+            summarise_date_range(start_date, end_date, initial_time_behind_opt, show_times_in_hours)
         },
         Err(msg) => {
             eprintln!("{}", msg);
@@ -87,7 +91,7 @@ fn parse_args_for_summarise_days(args: Vec<String>) -> Result<(NaiveDate, NaiveD
     return Ok((naive_start_date, naive_end_date, initial_time_behind_opt))
 }
 
-pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_time_behind_opt: Option<i64>) {
+pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_time_behind_opt: Option<i64>, show_times_in_hours: bool) {
     let seed_time: i64 = initial_time_behind_opt.unwrap_or(0);
     let mut aggregated: AggregateDay = AggregateDay::new(seed_time);
 
@@ -131,7 +135,8 @@ pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_
     if days_not_ended.len() > 0 {
         println!("Days not ended: {}", render_list_of_dates_for_user_info(&days_not_ended));
     }
-    let print_result: Result<(), String> = print_aggregated_day_summary(&aggregated, initial_time_behind_opt.is_some());
+    let print_result: Result<(), String> = print_aggregated_day_summary(
+        &aggregated, initial_time_behind_opt.is_some(), show_times_in_hours);
     if let Err(err_msg) = print_result {
         eprintln!("{}", err_msg);
         exit(1);
@@ -151,8 +156,8 @@ fn render_list_of_dates_for_user_info(dates: &Vec<String>) -> String {
     }
 }
 
-pub fn print_aggregated_day_summary(aggregate_day: &AggregateDay, include_overall_time_behind: bool) -> Result<(), String> {
-    let summary_result: Result<String, String> = aggregate_day.render_human_readable_summary(include_overall_time_behind);    
+pub fn print_aggregated_day_summary(aggregate_day: &AggregateDay, include_overall_time_behind: bool, show_times_in_hours: bool) -> Result<(), String> {
+    let summary_result: Result<String, String> = aggregate_day.render_human_readable_summary(include_overall_time_behind, show_times_in_hours);    
     return match summary_result {
         Ok(summary_str) => {
             println!("{}", summary_str);

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -220,14 +220,15 @@ pub fn summary(now: &DateTime<Local>, mut day: Day) {
 
 
 pub fn print_day_summary(day: &Day, use_config_for_time_behind: bool) -> Result<(), String> {
+    let config: Config = get_config();
+    let show_times_in_hours  = config.show_times_in_hours().unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT);
     let time_behind_opt: Option<i64> = match use_config_for_time_behind {
         true => {
-            let config: Config = get_config();
             Some(config.minutes_behind() * 60)
         },
         false => None,
     };
-    let summary_result: Result<String, String> = day.render_human_readable_summary(time_behind_opt);
+    let summary_result: Result<String, String> = day.render_human_readable_summary(time_behind_opt, show_times_in_hours);
     
     return match summary_result {
         Ok(summary_str) => {

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -3,13 +3,13 @@ use std::process::exit;
 
 use crate::units::day::{Day,read_day_from_date_str};
 use crate::units::aggregate_day::AggregateDay;
-use crate::utils::config::{Config, get_config, SHOW_TIMES_IN_HOURS_DEFAULT};
+use crate::utils::config::{Config, get_config};
 use crate::utils::dates_and_times::{get_local_now, DateRange};
 use crate::utils::misc::convert_input_to_seconds;
 
 pub fn summarise_week(args: Vec<String>) {
     let config: Config = get_config();
-    let show_times_in_hours: bool = config.show_times_in_hours().unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT);
+    let show_times_in_hours: bool = config.show_times_in_hours_or_default();
     match parse_args_for_summarise_week(args) {
         Ok((start_date, end_date, initial_time_behind_opt)) => {
             summarise_date_range(start_date, end_date, initial_time_behind_opt, show_times_in_hours);
@@ -49,7 +49,7 @@ fn parse_args_for_summarise_week(args: Vec<String>) -> Result<(NaiveDate, NaiveD
 
 pub fn summarise_days(args: Vec<String>) {
     let config: Config = get_config();
-    let show_times_in_hours: bool = config.show_times_in_hours().unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT);
+    let show_times_in_hours: bool = config.show_times_in_hours_or_default();
     match parse_args_for_summarise_days(args) {
         Ok((start_date, end_date, initial_time_behind_opt)) => {
             summarise_date_range(start_date, end_date, initial_time_behind_opt, show_times_in_hours)
@@ -221,7 +221,7 @@ pub fn summary(now: &DateTime<Local>, mut day: Day) {
 
 pub fn print_day_summary(day: &Day, use_config_for_time_behind: bool) -> Result<(), String> {
     let config: Config = get_config();
-    let show_times_in_hours  = config.show_times_in_hours().unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT);
+    let show_times_in_hours  = config.show_times_in_hours_or_default();
     let time_behind_opt: Option<i64> = match use_config_for_time_behind {
         true => {
             Some(config.minutes_behind() * 60)

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use crate::commands::day_summaries::{summary, summary_past, summarise_week, summ
 use crate::utils::file_io::create_base_dir_if_not_exists;
 use crate::utils::config::create_default_config_if_not_exists;
 
-const VERSION: &str = "2.5.0";
+const VERSION: &str = "2.5.1";
 
 
 #[derive(PartialEq,Clone)]

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -69,14 +69,14 @@ impl AggregateDay {
         return self.get_total_blocks() - self.num_breaks;
     }
 
-    pub fn render_human_readable_summary(&self, include_overall_time_behind: bool) -> Result<String, String> {
+    pub fn render_human_readable_summary(&self, include_overall_time_behind: bool, show_times_in_hours: bool) -> Result<String, String> {
         let mut summary_str: String = format!("Num days summarised: {}", self.num_days);
         summary_str += &format!(
-            "\nTotal work time (including breaks): {}", render_seconds_human_readable(self.total_time as i64));
+            "\nTotal work time (including breaks): {}", render_seconds_human_readable(self.total_time as i64, show_times_in_hours));
         summary_str += &format!(
-            "\nTotal time working (excluding breaks): {}", render_seconds_human_readable(self.get_total_time_done() as i64));
+            "\nTotal time working (excluding breaks): {}", render_seconds_human_readable(self.get_total_time_done() as i64, show_times_in_hours));
         summary_str += &format!(
-            "\nTotal time spent on break: {}", render_seconds_human_readable(self.total_break_time as i64));
+            "\nTotal time spent on break: {}", render_seconds_human_readable(self.total_break_time as i64, show_times_in_hours));
         summary_str += "\n";
         
         summary_str += &format!(
@@ -87,17 +87,17 @@ impl AggregateDay {
         summary_str += "\n";
         summary_str += &"\nTask times, blocks:";
         for (task_name, (time, blocks)) in self.task_totals.clone().into_iter() {
-            summary_str += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(time as i64), blocks);
+            summary_str += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(time as i64, show_times_in_hours), blocks);
         }
         summary_str += "\n";
 
-        summary_str += &format!("\nTime to do over period: {}", render_seconds_human_readable(self.total_time_to_do as i64));
+        summary_str += &format!("\nTime to do over period: {}", render_seconds_human_readable(self.total_time_to_do as i64, show_times_in_hours));
         summary_str += &format!(
-            "\nTime behind over period: {}", render_seconds_human_readable(self.get_time_behind_over_period()), 
+            "\nTime behind over period: {}", render_seconds_human_readable(self.get_time_behind_over_period(), show_times_in_hours), 
         );
         if include_overall_time_behind {
             summary_str += &format!(
-                "\nTime behind overall: {}", render_seconds_human_readable(self.get_time_behind_overall()), 
+                "\nTime behind overall: {}", render_seconds_human_readable(self.get_time_behind_overall(), show_times_in_hours), 
             );
         }
         return Ok(summary_str);

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -35,7 +35,7 @@ impl AggregateDay {
         self.total_time += day.get_day_length_secs().expect("Day has ended so day length should be known.") as u64;
         self.total_break_time += day.get_total_break_time_secs().expect("Day has ended so day length should be known.") as u64;
         self.num_breaks += day.get_number_of_breaks().expect("Day has ended so day length should be known.");
-        self.total_time_to_do += day.get_time_to_do();
+        self.total_time_to_do += day.get_time_to_do_secs();
         self.num_days += 1;
 
         let task_summaries: HashMap<String, (i64, u64)> = day.get_task_times_secs_and_num_blocks();

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -312,7 +312,7 @@ impl Day {
         return task_name_vec;
     }
 
-    pub fn render_human_readable_summary(&self, initial_time_behind_opt: Option<i64>) -> Result<String, String> {
+    pub fn render_human_readable_summary(&self, initial_time_behind_opt: Option<i64>, show_times_in_hours: bool) -> Result<String, String> {
         if !self.has_ended() {
             return Err("Can't summarise a day before it has ended!".to_string())
         }
@@ -327,11 +327,11 @@ impl Day {
         let time_done_secs: i64 = self.get_time_done_secs().unwrap();
 
         let mut summary_str: String = format!(
-            "Total time (from punch in to punch out): {}", render_seconds_human_readable(day_length)
+            "Total time (from punch in to punch out): {}", render_seconds_human_readable(day_length, show_times_in_hours)
         );
-        summary_str += &format!("\nTime done today: {}", render_seconds_human_readable(time_done_secs));
+        summary_str += &format!("\nTime done today: {}", render_seconds_human_readable(time_done_secs, show_times_in_hours));
         summary_str += &format!(
-            "\nTime spent on break: {}", render_seconds_human_readable(break_time)
+            "\nTime spent on break: {}", render_seconds_human_readable(break_time, show_times_in_hours)
         );
         summary_str += "\n";
 
@@ -344,15 +344,15 @@ impl Day {
         summary_str += &format!("\nTask times, blocks:");
         for task_name in self.get_tasks_in_chronological_order() {
             let (time, blocks) = task_summaries.get(&task_name).unwrap();
-            summary_str += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(*time), blocks);
+            summary_str += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(*time, show_times_in_hours), blocks);
         }
         summary_str += "\n";
 
-        summary_str += &format!("\nTime to do today: {}", render_seconds_human_readable(self.get_time_to_do_secs() as i64));
-        summary_str += &format!("\nTime left to do today: {}", render_seconds_human_readable(time_left));
+        summary_str += &format!("\nTime to do today: {}", render_seconds_human_readable(self.get_time_to_do_secs() as i64, show_times_in_hours));
+        summary_str += &format!("\nTime left to do today: {}", render_seconds_human_readable(time_left, show_times_in_hours));
         if let Some(initial_time_behind) = initial_time_behind_opt {
             let total_time_behind: i64 = initial_time_behind + time_left;
-            summary_str += &format!("\nTime behind overall: {}", render_seconds_human_readable(total_time_behind));
+            summary_str += &format!("\nTime behind overall: {}", render_seconds_human_readable(total_time_behind, show_times_in_hours));
         }
         return Ok(summary_str);
     }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -6,6 +6,7 @@ pub const CONFIG_FILE: &str = "punch.cfg";
 const DEFAULT_TIME_MINS: i64 = 480;
 const DEFAULT_PUNCH_IN_TASK: &str = "Starting-up";
 const DEFAULT_BREAK_TASK: &str = "Break";
+pub const SHOW_TIMES_IN_HOURS_DEFAULT: bool = true;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
@@ -61,6 +62,12 @@ impl Config {
         return self.minutes_behind_non_neg;
     }
     pub fn editor_path(&self) -> Option<&String> { return self.editor_path.as_ref(); }
+
+    pub fn show_times_in_hours(&self) -> Option<bool> { return self.show_times_in_hours; }
+
+    pub fn show_times_in_hours_or_default(&self) -> Option<bool> { 
+        return self.show_times_in_hours.unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT); 
+    }
 
     pub fn update_minutes_behind(&mut self, delta: i64) {
         let true_time_behind: i64 = self.minutes_behind() + delta;

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -65,7 +65,7 @@ impl Config {
 
     pub fn show_times_in_hours(&self) -> Option<bool> { return self.show_times_in_hours; }
 
-    pub fn show_times_in_hours_or_default(&self) -> Option<bool> { 
+    pub fn show_times_in_hours_or_default(&self) -> bool { 
         return self.show_times_in_hours.unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT); 
     }
 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     minutes_behind: i64,
     minutes_behind_non_neg: u64,
     editor_path: Option<String>,
+    show_times_in_hours: Option<bool>
 }
 
 impl Config {
@@ -22,7 +23,8 @@ impl Config {
         day_length: i64,
         default_punch_in_task: String,
         default_break_task: String,
-        minutes_behind: i64)
+        minutes_behind: i64,
+        show_times_in_hours: Option<bool>)
         -> Self {
         return Self {
             day_in_minutes: day_length,
@@ -31,6 +33,7 @@ impl Config {
             minutes_behind: minutes_behind,
             minutes_behind_non_neg: if minutes_behind < 0 { 0 } else { minutes_behind } as u64,
             editor_path: Some("vim".to_string()),
+            show_times_in_hours: show_times_in_hours,
         };
     }
 
@@ -107,7 +110,8 @@ pub fn create_default_config_if_not_exists() {
             DEFAULT_TIME_MINS,
             DEFAULT_PUNCH_IN_TASK.to_owned(),
             DEFAULT_BREAK_TASK.to_owned(),
-            0);
+            0,
+            Some(true));
         write_config(&config_path, &default_config);
     }
 }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -6,7 +6,7 @@ pub const CONFIG_FILE: &str = "punch.cfg";
 const DEFAULT_TIME_MINS: i64 = 480;
 const DEFAULT_PUNCH_IN_TASK: &str = "Starting-up";
 const DEFAULT_BREAK_TASK: &str = "Break";
-pub const SHOW_TIMES_IN_HOURS_DEFAULT: bool = true;
+const SHOW_TIMES_IN_HOURS_DEFAULT: bool = true;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -63,8 +63,6 @@ impl Config {
     }
     pub fn editor_path(&self) -> Option<&String> { return self.editor_path.as_ref(); }
 
-    pub fn show_times_in_hours(&self) -> Option<bool> { return self.show_times_in_hours; }
-
     pub fn show_times_in_hours_or_default(&self) -> bool { 
         return self.show_times_in_hours.unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT); 
     }

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -116,7 +116,7 @@ pub fn create_default_config_if_not_exists() {
             DEFAULT_PUNCH_IN_TASK.to_owned(),
             DEFAULT_BREAK_TASK.to_owned(),
             0,
-            Some(true));
+            Some(SHOW_TIMES_IN_HOURS_DEFAULT));
         write_config(&config_path, &default_config);
     }
 }

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -1,19 +1,19 @@
 use std::collections::HashMap;
 use regex::Regex;
 
-pub fn render_seconds_human_readable(secs: i64) -> String {
+pub fn render_seconds_human_readable(secs: i64, show_times_in_hours: bool) -> String {
     let (sign, sign_str): (i64, &str) = if secs < 0 {(-1, "-")} else {(1, "")};
     let abs_secs: i64 = sign * secs;
     let abs_output: String;
-    if abs_secs >= 60 * 60 {
+    if (abs_secs >= 60 * 60) & show_times_in_hours {
         let hours: i64 = abs_secs / (60 * 60);
         let seconds_left:i64 = abs_secs % (60 * 60);
-        abs_output =  format!("{}h {}", hours, render_seconds_human_readable(seconds_left));
+        abs_output =  format!("{}h {}", hours, render_seconds_human_readable(seconds_left, false));
     }
     else if abs_secs >= 60 {
         let minutes: i64 = abs_secs / 60;
         let seconds_left: i64 = abs_secs % 60;
-        abs_output = format!("{}m {}", minutes, render_seconds_human_readable(seconds_left));
+        abs_output = format!("{}m {}", minutes, render_seconds_human_readable(seconds_left, false));
     }
     else {
         abs_output = format!("{}s", abs_secs);

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -5,7 +5,7 @@ pub fn render_seconds_human_readable(secs: i64, show_times_in_hours: bool) -> St
     let (sign, sign_str): (i64, &str) = if secs < 0 {(-1, "-")} else {(1, "")};
     let abs_secs: i64 = sign * secs;
     let abs_output: String;
-    if (abs_secs >= 60 * 60) & show_times_in_hours {
+    if show_times_in_hours & (abs_secs >= 60 * 60) {
         let hours: i64 = abs_secs / (60 * 60);
         let seconds_left:i64 = abs_secs % (60 * 60);
         abs_output =  format!("{}h {}", hours, render_seconds_human_readable(seconds_left, false));


### PR DESCRIPTION
This PR adds a new configuration option (show_times_in_hours) to allow users to choose whether times elapsed shown in summaries are in hours minutes and seconds or just minutes and seconds. By default, this will be true but editing the config to add a false will change this back.

This should address issue #74 .

In addition, we fix a bug in how time to do is calculated in AggregatedDays which should fix #76 .