### PR TITLE
Patch@punchout time to do done

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "2.5.1"
+version = "2.5.2"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Once it's installed you can start your day by running `punch in`. The following 
 - `out`: Ends the day. If you end the day while on a break, the break is automatically ended. This also works if you end up working after midnight too.
 - `task`: Used to start a new time-block for working on a new task. Used for task time-tracking.
 - `view`: Allows you to see a string representation of your day.
-- `edit`: Allows you to edit your day so far.
+- `edit`: Allows you to edit your day so far. It opens up the day as a file in an editor (vim by default) so you can make any changes needed.
 - `summary`: Prints a summary of your day. Tells you how many minutes you have worked, how many minutes you have left and how far behind on time you have fallen (for instance, if you finished early one of the days and need to make that time back). It also gives a summary of the tasks you've done and the time spent too.
 - `note`: Used to add a note at the current time.
 - `add-summary`: Used to add a summary for what's been done for a particular task.
@@ -26,17 +26,35 @@ The following commands don't require you to have "punched in" for the day yet:
 - `summary-past`: Does the same as `summary` except you can pick some day in the past. It takes as argument a date string in yyyy-mm-dd format.
 - `summarise-week`: This prints a similar summary to the last two commands except it does it for a week's worth of days. Ran without argument, it summarises the last 7 days including today. Otherwise, you can provide it with a single date string argument, which allows you to summarise the week ending on that date. In addition, you can provide it with a second argument that specifies the time behind when starting the week, which adds an extra summary line.
 - `summarise-days`: This does the same as the previous command except you have to specify the start and end dates. If only one date is provided, it will just summarise that one day, if two date strings are provided, it summarises those days (inclusive). You can also provide a third argument indicating the time behind at the start of the period.
-- `edit-config`: Used to edit the configuration file for `punch`.
+- `edit-config`: Used to edit the configuration file for `punch`. It opens it up
 - `view-config`: Used to view the configuration file for `punch`.
 
 The config file will be stored at `~/.punch-card/punch.cfg`. This stores the length of your day in minutes (480 minutes or 8 hours by default) as well as storing how many minutes you have fallen behind.
 
 ## Installation
 
-At the moment, the only way to install is to build the program locally. You'll need to have Rust and Cargo installed as well as Vim. In addition, this has only been tested on a Mac (though it should work on Linux and Windows too, with different instructions).
+At the moment, the only way to install is to build the program locally. You'll need to have Rust and Cargo installed. In addition, you'll need some sort of text editor installed to use commands such as `punch edit`. The following instructions should work for any *NIX OS (though something like it should work on pretty much any OS including Windows).
 
 1. Clone this repository to your computer.
 2. Run 'cargo build --release'. The executable will then appear in `/target/release/punch`
 3. Copy it to somewhere on your PATH
 
 Alternatively, you can run the included `install.sh` after you have cloned your repository, provided you have a `/usr/local/bin/` directory. You will also need to add `usr/local/bin/` to your PATH if it hasn't been added already.
+
+## Using your own favourite editor
+
+As stated above, we assume Vim as the default editor for use with `punch edit` and `punch edit-config`. However, if you prefer a different editor, this can be changed in one of two ways:
+
+1. You can set the `editor_path` in the config
+2. You can set the `EDITOR` environment variable
+
+If the editor in question is already on the `PATH`, then you just need to provide the name for the editor, otherwise, you need to provide the full path for it.
+In addition, most GUI based editors won't work exactly as is: `punch-card` will open the editor and not wait for the user to make the changes. 
+A lot of popular GUI based editors provide a "wait" flag that will work instead. Some examples (though these depend on what version and sometimes what OS you have too):
+
+1. gedit has `gedit -w` or `gedit --wait`
+2. VS Code has `code --wait`
+3. Sublime has `subl -n -w` (`-n` for a new window and then `-w` for wait as with the others)
+
+If you can't find a way to do this from your editor's documentation, try searching for how to use that editor as the default editor for git. 
+The answer that works for git will likely work for this too.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following commands don't require you to have "punched in" for the day yet:
 - `summary-past`: Does the same as `summary` except you can pick some day in the past. It takes as argument a date string in yyyy-mm-dd format.
 - `summarise-week`: This prints a similar summary to the last two commands except it does it for a week's worth of days. Ran without argument, it summarises the last 7 days including today. Otherwise, you can provide it with a single date string argument, which allows you to summarise the week ending on that date. In addition, you can provide it with a second argument that specifies the time behind when starting the week, which adds an extra summary line.
 - `summarise-days`: This does the same as the previous command except you have to specify the start and end dates. If only one date is provided, it will just summarise that one day, if two date strings are provided, it summarises those days (inclusive). You can also provide a third argument indicating the time behind at the start of the period.
-- `edit-config`: Used to edit the configuration file for `punch`. It opens it up
+- `edit-config`: Used to edit the configuration file for `punch`. It opens it up the config file in an editor (vim by default).
 - `view-config`: Used to view the configuration file for `punch`.
 
 The config file will be stored at `~/.punch-card/punch.cfg`. This stores the length of your day in minutes (480 minutes or 8 hours by default) as well as storing how many minutes you have fallen behind.

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -355,7 +355,7 @@ fn update_time_behind(day: Day) -> Result<(), String> {
     if day.has_ended() {
         let mut config: Config = get_config();
         let time_left: i64 = day.get_time_left_secs().expect("Day is over so we should have a time left!");
-        config.update_minutes_behind(time_left / 60);
+        config.update_time_behind(time_left);
         update_config(config);
         return Ok(());
     }

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -1,44 +1,44 @@
-use std::process::exit;
-use chrono::prelude::{DateTime, Local};
 use crate::commands::day_summaries::print_day_summary;
 use crate::utils::file_io::SafeFileEdit;
+use chrono::prelude::{DateTime, Local};
+use std::process::exit;
 
-use crate::units::day::{
-    Day,
-    read_day,
-    read_day_from_date_str,
-    write_day};
+use crate::units::day::{read_day, read_day_from_date_str, write_day, Day};
 
-use crate::utils::config::{Config, get_config, update_config};
+use crate::utils::config::{get_config, update_config, Config};
 
 pub fn punch_in(now: &DateTime<Local>, other_args: Vec<String>) {
     if let Ok(_) = read_day(now) {
         println!("You've already clocked in for the day!");
-    }
-    else{
+    } else {
         let parsed_args: (String, u64) = get_other_args_for_punch_in(other_args);
         let new_day: Day = Day::new(&now, parsed_args.0, parsed_args.1, None);
-        println!("Clocking in for the day at '{}'", &new_day.get_day_start_as_str());
+        println!(
+            "Clocking in for the day at '{}'",
+            &new_day.get_day_start_as_str()
+        );
         write_day(&new_day);
     }
 }
 
 fn get_other_args_for_punch_in(other_args: Vec<String>) -> (String, u64) {
     let default_time_to_do: u64 = get_default_day_in_minutes();
-    println!("Using the default time to do for the day: {} minutes", default_time_to_do);
-    let punch_in_task: String; 
+    println!(
+        "Using the default time to do for the day: {} minutes",
+        default_time_to_do
+    );
+    let punch_in_task: String;
     if other_args.len() == 0 {
         punch_in_task = get_default_punch_in_task();
         println!(
-            "No start task for the day provided. Using the default value: '{}'", 
-            punch_in_task);
-    }
-    else {
+            "No start task for the day provided. Using the default value: '{}'",
+            punch_in_task
+        );
+    } else {
         punch_in_task = other_args[0].to_owned();
     }
     println!("Remember: You can use `punch edit` to change anything about the day.");
-    return (punch_in_task, default_time_to_do)
-
+    return (punch_in_task, default_time_to_do);
 }
 
 fn get_default_day_in_minutes() -> u64 {
@@ -57,7 +57,10 @@ pub fn punch_out(now: &DateTime<Local>, mut day: Day, other_args: Vec<String>) {
     }
     let time_to_do_done: bool = time_to_do_done_result.unwrap();
     if let Ok(_) = day.end_day_at(&now, time_to_do_done) {
-        println!("Punching out for the day at '{}'", &day.get_day_end_as_str().unwrap().trim());        
+        println!(
+            "Punching out for the day at '{}'",
+            &day.get_day_end_as_str().unwrap().trim()
+        );
         let summary_result = print_day_summary(&day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
@@ -71,8 +74,7 @@ pub fn punch_out(now: &DateTime<Local>, mut day: Day, other_args: Vec<String>) {
                 exit(1);
             }
         }
-    }
-    else {
+    } else {
         println!("Can't punch out: Already punched out for the day!");
     }
 }
@@ -86,9 +88,9 @@ fn parse_args_for_punch_out(other_args: Vec<String>) -> Result<bool, String> {
                 return Err(format!("Unrecognised argument or flag: {}", arg));
             }
             return Ok(true);
-        },
+        }
         _ => Err("punch out takes at most 1 argument!".to_owned()),
-    }
+    };
 }
 
 pub fn take_break(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) {
@@ -98,21 +100,24 @@ pub fn take_break(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) 
         exit(1);
     }
     let break_result: Result<(), &str> = day.start_break_at(
-        resolved_break_name.expect("break_name error should already have been handled"), &now
+        resolved_break_name.expect("break_name error should already have been handled"),
+        &now,
     );
     if let Ok(_) = break_result {
         println!("Taking a break at '{}'", &now);
         write_day(&day);
 
-        if !day.has_ended() {day.end_day_at(&now, false).expect("We should be able to end the day");}
+        if !day.has_ended() {
+            day.end_day_at(&now, false)
+                .expect("We should be able to end the day");
+        }
 
         let summary_result = print_day_summary(&day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
         }
-    }
-    else {
+    } else {
         let msg = break_result.unwrap_err();
         eprintln!("{}", msg);
         exit(1);
@@ -129,8 +134,8 @@ pub fn get_name_for_break(other_args: Vec<String>) -> Result<String, &'static st
 }
 
 pub fn resume(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) {
-    let new_block_task_result: Result<String, String> = get_resume_task_from_args(
-        other_args, day.clone());
+    let new_block_task_result: Result<String, String> =
+        get_resume_task_from_args(other_args, day.clone());
     if let Err(msg) = new_block_task_result {
         eprintln!("{}", msg);
         exit(1);
@@ -141,15 +146,17 @@ pub fn resume(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) {
     if let Ok(_) = resume_result {
         println!("Back to work at '{}'", &now);
         write_day(&day);
-        if !day.has_ended() {day.end_day_at(&now, false).expect("We should be able to end the day");}
+        if !day.has_ended() {
+            day.end_day_at(&now, false)
+                .expect("We should be able to end the day");
+        }
 
         let summary_result = print_day_summary(&day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
         }
-    }
-    else {
+    } else {
         let msg = resume_result.unwrap_err();
         eprintln!("{}", msg);
         exit(1);
@@ -161,12 +168,12 @@ fn get_resume_task_from_args(other_args: Vec<String>, day: Day) -> Result<String
         0 => Ok(day.get_task_name(-2)),
         1 => Ok(other_args[0].to_owned()),
         _ => Err("'punch resume' should have at most one argument!".to_string()),
-    }
+    };
 }
 
 pub fn punch_back_in(now: &DateTime<Local>, other_args: Vec<String>, mut day: Day) {
-    let new_block_task_result: Result<String, String> = get_restart_task_from_args(
-        other_args, day.clone());
+    let new_block_task_result: Result<String, String> =
+        get_restart_task_from_args(other_args, day.clone());
     if let Err(msg) = new_block_task_result {
         eprintln!("{}", msg);
         exit(1);
@@ -174,11 +181,15 @@ pub fn punch_back_in(now: &DateTime<Local>, other_args: Vec<String>, mut day: Da
     let new_block_task: String = new_block_task_result.expect("We've precluded no arguments");
 
     let default_break_name = get_config().get_default_break_task().to_owned();
-    let restart_result: Result<i64, &str> = day.restart_day(default_break_name, new_block_task, &now);
+    let restart_result: Result<i64, &str> =
+        day.restart_day(default_break_name, new_block_task, &now);
     if let Ok(seconds_left_before) = restart_result {
         println!("Back to work at '{}'", &now);
         write_day(&day);
-        if !day.has_ended() {day.end_day_at(&now, false).expect("We should be able to end the day");}
+        if !day.has_ended() {
+            day.end_day_at(&now, false)
+                .expect("We should be able to end the day");
+        }
         let mut config: Config = get_config();
         config.update_minutes_behind(-seconds_left_before / 60);
         update_config(config);
@@ -188,8 +199,7 @@ pub fn punch_back_in(now: &DateTime<Local>, other_args: Vec<String>, mut day: Da
             eprintln!("{}", err_msg);
             exit(1);
         }
-    }
-    else {
+    } else {
         let msg = restart_result.unwrap_err();
         eprintln!("{}", msg);
         exit(1);
@@ -201,7 +211,7 @@ fn get_restart_task_from_args(other_args: Vec<String>, day: Day) -> Result<Strin
         0 => Ok(day.get_task_name(-1)),
         1 => Ok(other_args[0].to_owned()),
         _ => Err("'punch back-in' should have at most one argument!".to_string()),
-    }
+    };
 }
 
 pub fn switch_to_new_task(now: &DateTime<Local>, mut day: Day, other_args: Vec<String>) {
@@ -209,22 +219,24 @@ pub fn switch_to_new_task(now: &DateTime<Local>, mut day: Day, other_args: Vec<S
     if let Err(msg) = new_block_task_result {
         eprintln!("{}", msg);
         exit(1);
-    } 
+    }
 
     let new_block_task: String = new_block_task_result.expect("We've handled errors");
     let result: Result<(), &str> = day.start_new_block(new_block_task.to_owned(), &now);
     if let Ok(_) = result {
         println!("Now working on '{}' from '{}'", &new_block_task, &now);
         write_day(&day);
-        if !day.has_ended() {day.end_day_at(&now, false).expect("We should be able to end the day");}
+        if !day.has_ended() {
+            day.end_day_at(&now, false)
+                .expect("We should be able to end the day");
+        }
 
         let summary_result = print_day_summary(&day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
         }
-    }
-    else {
+    } else {
         let msg = result.unwrap_err();
         eprintln!("{}", msg);
         exit(1);
@@ -246,21 +258,18 @@ pub fn view_day(day: Day) {
 
 pub fn view_past(other_args: Vec<String>) {
     let arg_result: Result<String, String> = parse_args_for_view_past(other_args);
-    
+
     if let Err(msg) = arg_result {
         eprintln!("{}", msg);
         exit(1);
-    }
-    else if let Ok(date_str) = arg_result {
+    } else if let Ok(date_str) = arg_result {
         if let Ok(day) = read_day_from_date_str(&date_str) {
             println!("Here is {}:\n", date_str);
             println!("{}", day.as_string());
-        }
-        else {
+        } else {
             eprintln!("'{}' does not have a day associated with it!", date_str);
         }
     }
-    
 }
 
 fn parse_args_for_view_past(other_args: Vec<String>) -> Result<String, String> {
@@ -276,11 +285,15 @@ pub fn edit_day(day: Day) {
 
 pub fn add_summary_to_today(mut day: Day, other_args: Vec<String>) {
     if other_args.len() != 4 {
-        println!("'punch add-summary' takes exactly 4 arguments: category, project, task and summary.")
-    }
-    else {
+        println!(
+            "'punch add-summary' takes exactly 4 arguments: category, project, task and summary."
+        )
+    } else {
         let (category, project, task, summary) = (
-            other_args[0].to_string(), other_args[1].to_string(), other_args[2].to_string(), other_args[3].to_string()
+            other_args[0].to_string(),
+            other_args[1].to_string(),
+            other_args[2].to_string(),
+            other_args[3].to_string(),
         );
         day.add_summary(category, project, task, summary);
         write_day(&day);
@@ -302,12 +315,12 @@ pub fn add_note_to_today(now: &DateTime<Local>, mut day: Day, other_args: Vec<St
     if other_args.len() == 0 {
         eprintln!("'punch note' requires a msg argument!");
         exit(1);
-    }
-    else if other_args.len() > 1 {
-        eprintln!("'punch note' takes a single argument. Consider wrapping your message in quotes.");
+    } else if other_args.len() > 1 {
+        eprintln!(
+            "'punch note' takes a single argument. Consider wrapping your message in quotes."
+        );
         exit(1);
-    }
-    else {
+    } else {
         let msg: String = (&other_args[0]).to_string();
         day.add_note(now, &msg);
         write_day(&day);
@@ -323,19 +336,21 @@ pub fn update_current_task_name(now: &DateTime<Local>, mut day: Day, other_args:
     }
     let task_name = task_name_result.expect("Error already handled!");
     let change_task_result: Result<(), &str> = day.update_current_task_name(task_name.clone());
-    
+
     if let Ok(_) = change_task_result {
         println!("Updated the current task to '{}'", &task_name);
         write_day(&day);
-        if !day.has_ended() {day.end_day_at(&now, false).expect("We should be able to end the day");}
+        if !day.has_ended() {
+            day.end_day_at(&now, false)
+                .expect("We should be able to end the day");
+        }
 
         let summary_result = print_day_summary(&day, true);
         if let Err(err_msg) = summary_result {
             eprintln!("{}", err_msg);
             exit(1);
         }
-    }
-    else {
+    } else {
         let msg = change_task_result.unwrap_err();
         eprintln!("{}", msg);
         exit(1);
@@ -350,16 +365,16 @@ fn get_new_task_name_from_args(other_args: Vec<String>) -> Result<String, String
     };
 }
 
-
 fn update_time_behind(day: Day) -> Result<(), String> {
     if day.has_ended() {
         let mut config: Config = get_config();
-        let time_left: i64 = day.get_time_left_secs().expect("Day is over so we should have a time left!");
+        let time_left: i64 = day
+            .get_time_left_secs()
+            .expect("Day is over so we should have a time left!");
         config.update_time_behind(time_left);
         update_config(config);
         return Ok(());
-    }
-    else {
+    } else {
         return Err("Can't update time behind: The day isn't over yet".to_string());
     }
 }

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -17,7 +17,7 @@ pub fn punch_in(now: &DateTime<Local>, other_args: Vec<String>) {
     }
     else{
         let parsed_args: (String, u64) = get_other_args_for_punch_in(other_args);
-        let new_day: Day = Day::new(&now, parsed_args.0, parsed_args.1);
+        let new_day: Day = Day::new(&now, parsed_args.0, parsed_args.1, None);
         println!("Clocking in for the day at '{}'", &new_day.get_day_start_as_str());
         write_day(&new_day);
     }

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -1,9 +1,9 @@
 use chrono::{DateTime, Duration, Local, NaiveDate};
 use std::process::exit;
 
-use crate::units::day::{Day,read_day_from_date_str};
 use crate::units::aggregate_day::AggregateDay;
-use crate::utils::config::{Config, get_config};
+use crate::units::day::{read_day_from_date_str, Day};
+use crate::utils::config::{get_config, Config};
 use crate::utils::dates_and_times::{get_local_now, DateRange};
 use crate::utils::misc::convert_input_to_seconds;
 
@@ -12,8 +12,13 @@ pub fn summarise_week(args: Vec<String>) {
     let show_times_in_hours: bool = config.show_times_in_hours_or_default();
     match parse_args_for_summarise_week(args) {
         Ok((start_date, end_date, initial_time_behind_opt)) => {
-            summarise_date_range(start_date, end_date, initial_time_behind_opt, show_times_in_hours);
-        },
+            summarise_date_range(
+                start_date,
+                end_date,
+                initial_time_behind_opt,
+                show_times_in_hours,
+            );
+        }
         Err(msg) => {
             eprintln!("{}", msg);
             exit(1);
@@ -21,29 +26,35 @@ pub fn summarise_week(args: Vec<String>) {
     }
 }
 
-fn parse_args_for_summarise_week(args: Vec<String>) -> Result<(NaiveDate, NaiveDate, Option<i64>), String> {
+fn parse_args_for_summarise_week(
+    args: Vec<String>,
+) -> Result<(NaiveDate, NaiveDate, Option<i64>), String> {
     if args.len() > 2 {
         return Err("Too many args found for summarise_week".to_owned());
     }
 
-    let current_date = if args.len() == 0 {get_local_now().date_naive()} else {
-            let parse_date_result = NaiveDate::parse_from_str(&args[0], "%Y-%m-%d");
-            if let Err(_) = parse_date_result {
-                return Err(format!("First argument for summarise-week must be a date of the form 'YYYY-mm-dd'. Got: '{}'", args[0]));
-            }
-            parse_date_result.expect("Error already handled")
-        };
-    
+    let current_date = if args.len() == 0 {
+        get_local_now().date_naive()
+    } else {
+        let parse_date_result = NaiveDate::parse_from_str(&args[0], "%Y-%m-%d");
+        if let Err(_) = parse_date_result {
+            return Err(format!("First argument for summarise-week must be a date of the form 'YYYY-mm-dd'. Got: '{}'", args[0]));
+        }
+        parse_date_result.expect("Error already handled")
+    };
+
     let week_before: NaiveDate = current_date - Duration::days(6);
 
     let intial_time_behind_opt = if args.len() == 2 {
-            let parse_result: Result<i64, String> = convert_input_to_seconds(&args[1]);
-            if let Err(err_msg) = parse_result {
-                return Err(err_msg);
-            }
-            Some(parse_result.expect("Error from parsing i64 already handled!"))
-        } else {None};
-    
+        let parse_result: Result<i64, String> = convert_input_to_seconds(&args[1]);
+        if let Err(err_msg) = parse_result {
+            return Err(err_msg);
+        }
+        Some(parse_result.expect("Error from parsing i64 already handled!"))
+    } else {
+        None
+    };
+
     return Ok((week_before, current_date, intial_time_behind_opt));
 }
 
@@ -51,9 +62,12 @@ pub fn summarise_days(args: Vec<String>) {
     let config: Config = get_config();
     let show_times_in_hours: bool = config.show_times_in_hours_or_default();
     match parse_args_for_summarise_days(args) {
-        Ok((start_date, end_date, initial_time_behind_opt)) => {
-            summarise_date_range(start_date, end_date, initial_time_behind_opt, show_times_in_hours)
-        },
+        Ok((start_date, end_date, initial_time_behind_opt)) => summarise_date_range(
+            start_date,
+            end_date,
+            initial_time_behind_opt,
+            show_times_in_hours,
+        ),
         Err(msg) => {
             eprintln!("{}", msg);
             exit(1);
@@ -61,37 +75,53 @@ pub fn summarise_days(args: Vec<String>) {
     }
 }
 
-fn parse_args_for_summarise_days(args: Vec<String>) -> Result<(NaiveDate, NaiveDate, Option<i64>), String> {
+fn parse_args_for_summarise_days(
+    args: Vec<String>,
+) -> Result<(NaiveDate, NaiveDate, Option<i64>), String> {
     if args.len() == 0 {
         return Err("summarise-days must have at least one argument.".to_string());
     }
     if args.len() > 3 {
         return Err("summarise-days must have at most three arguments.".to_string());
     }
-    let naive_date_result:Result<NaiveDate, chrono::ParseError>  = NaiveDate::parse_from_str(&args[0], "%Y-%m-%d");
+    let naive_date_result: Result<NaiveDate, chrono::ParseError> =
+        NaiveDate::parse_from_str(&args[0], "%Y-%m-%d");
     if let Err(_) = naive_date_result {
-        return Err(format!("First argument for summarise-days must be a date of the form 'YYYY-mm-dd'. Got: '{}'", args[0]));
+        return Err(format!(
+            "First argument for summarise-days must be a date of the form 'YYYY-mm-dd'. Got: '{}'",
+            args[0]
+        ));
     }
     let naive_start_date = naive_date_result.expect("Error for this has already been handled!");
     let naive_end_date: NaiveDate = if args.len() >= 2 {
-            let naive_end_date_result: Result<NaiveDate, chrono::ParseError>  = NaiveDate::parse_from_str(&args[1], "%Y-%m-%d");
-            if let Err(_) = naive_end_date_result {
-                return Err(format!("Second argument for summarise-days must be a date of the form 'YYYY-mm-dd'. Got: '{}'", args[1]));
-            }
-            naive_end_date_result.expect("Error for this has already been handled!")
-        } else {naive_start_date};
+        let naive_end_date_result: Result<NaiveDate, chrono::ParseError> =
+            NaiveDate::parse_from_str(&args[1], "%Y-%m-%d");
+        if let Err(_) = naive_end_date_result {
+            return Err(format!("Second argument for summarise-days must be a date of the form 'YYYY-mm-dd'. Got: '{}'", args[1]));
+        }
+        naive_end_date_result.expect("Error for this has already been handled!")
+    } else {
+        naive_start_date
+    };
     let initial_time_behind_opt = if args.len() == 3 {
         let parse_result: Result<i64, String> = convert_input_to_seconds(&args[2]);
         if let Err(err_msg) = parse_result {
             return Err(err_msg);
         }
         Some(parse_result.expect("Error for this has already been handled!"))
-        } else {None};
+    } else {
+        None
+    };
 
-    return Ok((naive_start_date, naive_end_date, initial_time_behind_opt))
+    return Ok((naive_start_date, naive_end_date, initial_time_behind_opt));
 }
 
-pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_time_behind_opt: Option<i64>, show_times_in_hours: bool) {
+pub fn summarise_date_range(
+    start_date: NaiveDate,
+    end_date: NaiveDate,
+    initial_time_behind_opt: Option<i64>,
+    show_times_in_hours: bool,
+) {
     let seed_time: i64 = initial_time_behind_opt.unwrap_or(0);
     let mut aggregated: AggregateDay = AggregateDay::new(seed_time);
 
@@ -117,8 +147,7 @@ pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_
                     exit(1);
                 }
             }
-        }
-        else if !this_day.has_ended() {
+        } else if !this_day.has_ended() {
             days_not_ended.push(this_date_str.clone());
             continue;
         }
@@ -128,15 +157,27 @@ pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_
         };
         days_aggregated.push(this_date_str.clone());
     }
-    println!("Days aggregated: {}", render_list_of_dates_for_user_info(&days_aggregated));
+    println!(
+        "Days aggregated: {}",
+        render_list_of_dates_for_user_info(&days_aggregated)
+    );
     if days_not_there.len() > 0 {
-        println!("Days not there: {}", render_list_of_dates_for_user_info(&days_not_there));
+        println!(
+            "Days not there: {}",
+            render_list_of_dates_for_user_info(&days_not_there)
+        );
     }
     if days_not_ended.len() > 0 {
-        println!("Days not ended: {}", render_list_of_dates_for_user_info(&days_not_ended));
+        println!(
+            "Days not ended: {}",
+            render_list_of_dates_for_user_info(&days_not_ended)
+        );
     }
     let print_result: Result<(), String> = print_aggregated_day_summary(
-        &aggregated, initial_time_behind_opt.is_some(), show_times_in_hours);
+        &aggregated,
+        initial_time_behind_opt.is_some(),
+        show_times_in_hours,
+    );
     if let Err(err_msg) = print_result {
         eprintln!("{}", err_msg);
         exit(1);
@@ -147,24 +188,27 @@ fn render_list_of_dates_for_user_info(dates: &Vec<String>) -> String {
     let max_dates: usize = 5;
     if dates.len() == max_dates {
         return "None".to_string();
-    }
-    else if dates.len() <= 5 {
+    } else if dates.len() <= 5 {
         return dates.join(", ");
-    }
-    else {
+    } else {
         return dates[..max_dates].join(", ") + ", ...";
     }
 }
 
-pub fn print_aggregated_day_summary(aggregate_day: &AggregateDay, include_overall_time_behind: bool, show_times_in_hours: bool) -> Result<(), String> {
-    let summary_result: Result<String, String> = aggregate_day.render_human_readable_summary(include_overall_time_behind, show_times_in_hours);    
+pub fn print_aggregated_day_summary(
+    aggregate_day: &AggregateDay,
+    include_overall_time_behind: bool,
+    show_times_in_hours: bool,
+) -> Result<(), String> {
+    let summary_result: Result<String, String> = aggregate_day
+        .render_human_readable_summary(include_overall_time_behind, show_times_in_hours);
     return match summary_result {
         Ok(summary_str) => {
             println!("{}", summary_str);
             Ok(())
-        },
+        }
         Err(err_msg) => Err(err_msg),
-    }
+    };
 }
 
 pub fn summary_past(args: Vec<String>) {
@@ -191,14 +235,18 @@ fn parse_args_for_summary_past(args: Vec<String>) -> Result<NaiveDate, String> {
     return match args.len() {
         0 => Err("'punch summary-past' takes a single argument. None were given.".to_string()),
         1 => {
-            let parse_result: Result<NaiveDate, chrono::ParseError> = NaiveDate::parse_from_str(&args[0], "%Y-%m-%d");
+            let parse_result: Result<NaiveDate, chrono::ParseError> =
+                NaiveDate::parse_from_str(&args[0], "%Y-%m-%d");
             if let Err(err_contents) = parse_result {
                 return Err(err_contents.to_string());
             }
             Ok(parse_result.expect("Error for this has already been processed."))
-        },
-        a => Err(format!("'punch summary-past' takes a single argument. {} were given.", a)),
-    }
+        }
+        a => Err(format!(
+            "'punch summary-past' takes a single argument. {} were given.",
+            a
+        )),
+    };
 }
 
 pub fn summary(now: &DateTime<Local>, mut day: Day) {
@@ -209,7 +257,7 @@ pub fn summary(now: &DateTime<Local>, mut day: Day) {
             Err(err_msg) => {
                 eprintln!("Couldn't end day: {}", err_msg);
                 exit(1);
-            },
+            }
         }
     }
     if let Err(err_msg) = print_day_summary(&day, true) {
@@ -218,23 +266,21 @@ pub fn summary(now: &DateTime<Local>, mut day: Day) {
     }
 }
 
-
 pub fn print_day_summary(day: &Day, use_config_for_time_behind: bool) -> Result<(), String> {
     let config: Config = get_config();
-    let show_times_in_hours  = config.show_times_in_hours_or_default();
+    let show_times_in_hours = config.show_times_in_hours_or_default();
     let time_behind_opt: Option<i64> = match use_config_for_time_behind {
-        true => {
-            Some(config.minutes_behind() * 60)
-        },
+        true => Some(config.minutes_behind() * 60),
         false => None,
     };
-    let summary_result: Result<String, String> = day.render_human_readable_summary(time_behind_opt, show_times_in_hours);
-    
+    let summary_result: Result<String, String> =
+        day.render_human_readable_summary(time_behind_opt, show_times_in_hours);
+
     return match summary_result {
         Ok(summary_str) => {
             println!("{}", summary_str);
             Ok(())
-        },
+        }
         Err(err_msg) => Err(err_msg),
-    }
+    };
 }

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -110,7 +110,7 @@ pub fn summarise_date_range(start_date: NaiveDate, end_date: NaiveDate, initial_
         }
         let mut this_day: Day = this_day_result.expect("Already handled error!");
         if !this_day.has_ended() && (local_date == todays_date) {
-            match this_day.end_day_at(&local_now) {
+            match this_day.end_day_at(&local_now, false) {
                 Ok(()) => (),
                 Err(err_msg) => {
                     eprintln!("Failed to end today: {err_msg}");
@@ -203,7 +203,7 @@ fn parse_args_for_summary_past(args: Vec<String>) -> Result<NaiveDate, String> {
 
 pub fn summary(now: &DateTime<Local>, mut day: Day) {
     if !day.has_ended() {
-        let end_result: Result<(), &str> = day.end_day_at(&now);
+        let end_result: Result<(), &str> = day.end_day_at(&now, false);
         match end_result {
             Ok(_) => (),
             Err(err_msg) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
+pub mod commands;
 pub mod units;
 pub mod utils;
-pub mod commands;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,35 +1,23 @@
+use chrono::prelude::{DateTime, Local};
 use std::env::args;
 use std::process::exit;
-use chrono::prelude::{DateTime, Local};
 
 mod commands;
 mod units;
 mod utils;
-use crate::units::day::{create_daily_dir_if_not_exists,get_current_day,Day};
 use crate::commands::core::{
-    punch_in,
-    punch_out,
-    punch_back_in,
-    take_break,
-    resume,
-    view_day,
-    view_past,
-    edit_day,
-    switch_to_new_task,
-    update_current_task_name,
-    add_note_to_today,
-    add_summary_to_today,
-    view_config,
-    edit_config,
+    add_note_to_today, add_summary_to_today, edit_config, edit_day, punch_back_in, punch_in,
+    punch_out, resume, switch_to_new_task, take_break, update_current_task_name, view_config,
+    view_day, view_past,
 };
-use crate::commands::day_summaries::{summary, summary_past, summarise_week, summarise_days};
-use crate::utils::file_io::create_base_dir_if_not_exists;
+use crate::commands::day_summaries::{summarise_days, summarise_week, summary, summary_past};
+use crate::units::day::{create_daily_dir_if_not_exists, get_current_day, Day};
 use crate::utils::config::create_default_config_if_not_exists;
+use crate::utils::file_io::create_base_dir_if_not_exists;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-
-#[derive(PartialEq,Clone)]
+#[derive(PartialEq, Clone)]
 enum SubCommand {
     In(Vec<String>),
     Out(Vec<String>),
@@ -76,9 +64,9 @@ impl SubCommand {
             "update-task" => Self::UpdateTask(other_args),
             "version" | "-v" | "--version" => Self::Version(other_args),
             other => Self::Invalid(other.to_string()),
-        }
+        };
     }
-    
+
     fn to_string(self) -> String {
         return match self {
             Self::In(_) => "in",
@@ -101,18 +89,36 @@ impl SubCommand {
             Self::UpdateTask(_) => "update-task",
             Self::Version(_) => "version",
             Self::Invalid(_) => "invalid",
-        }.to_string();
+        }
+        .to_string();
     }
 
     fn get_allowed_strings() -> Vec<String> {
         return Vec::from(
             [
-                "in", "out", "back-in", "pause", "resume", "summary", "summary-past",
-                "summarise-week", "summarise-days", "view", "view-past", "edit",
-                "task", "note", "edit-config", "add-summary", "update-task",
-                "version", "-v", "--version"
-            ].map(|x: &str| x.to_string())
-        )
+                "in",
+                "out",
+                "back-in",
+                "pause",
+                "resume",
+                "summary",
+                "summary-past",
+                "summarise-week",
+                "summarise-days",
+                "view",
+                "view-past",
+                "edit",
+                "task",
+                "note",
+                "edit-config",
+                "add-summary",
+                "update-task",
+                "version",
+                "-v",
+                "--version",
+            ]
+            .map(|x: &str| x.to_string()),
+        );
     }
 }
 
@@ -153,7 +159,7 @@ fn run_command(command: SubCommand, now: DateTime<Local>) {
         SubCommand::ViewConfig(_) => view_config(),
         SubCommand::SummariseWeek(other_args) => summarise_week(other_args),
         SubCommand::SummariseDays(other_args) => summarise_days(other_args),
-        _ => {processed = false},
+        _ => processed = false,
     }
     if processed {
         exit(0);
@@ -178,13 +184,21 @@ fn run_command(command: SubCommand, now: DateTime<Local>) {
         SubCommand::Note(other_args) => add_note_to_today(&now, day, other_args),
         SubCommand::AddSummary(other_args) => add_summary_to_today(day, other_args),
         SubCommand::UpdateTask(other_args) => update_current_task_name(&now, day, other_args),
-        SubCommand::Version(_) => unreachable!("`punch version/--version/-v` commands should already be processed."),
-        _ => unreachable!("'punch {}' commands shouldn't be processed here.", command.to_string()),
+        SubCommand::Version(_) => {
+            unreachable!("`punch version/--version/-v` commands should already be processed.")
+        }
+        _ => unreachable!(
+            "'punch {}' commands shouldn't be processed here.",
+            command.to_string()
+        ),
     }
 }
 
 fn handle_invalid_cmd(command: &str) {
-    eprintln!("'{}' is not a valid subcommand for punch. Try one of the following:", command);
+    eprintln!(
+        "'{}' is not a valid subcommand for punch. Try one of the following:",
+        command
+    );
     for str_subcommand in SubCommand::get_allowed_strings() {
         eprintln!("\t{}", str_subcommand);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use crate::commands::day_summaries::{summary, summary_past, summarise_week, summ
 use crate::utils::file_io::create_base_dir_if_not_exists;
 use crate::utils::config::create_default_config_if_not_exists;
 
-const VERSION: &str = "2.5.1";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 
 #[derive(PartialEq,Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ fn run_command(command: SubCommand, now: DateTime<Local>) {
     let day: Day = possible_day.unwrap();
 
     match command {
-        SubCommand::Out(_) => punch_out(&now, day),
+        SubCommand::Out(other_args) => punch_out(&now, day, other_args),
         SubCommand::BackIn(other_args) => punch_back_in(&now, other_args, day),
         SubCommand::Pause(other_args) => take_break(&now, other_args, day),
         SubCommand::Resume(other_args) => resume(&now, other_args, day),

--- a/src/units/aggregate_day.rs
+++ b/src/units/aggregate_day.rs
@@ -3,15 +3,14 @@ use std::collections::HashMap;
 use crate::units::day::Day;
 use crate::utils::misc::render_seconds_human_readable;
 
-
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 pub struct AggregateDay {
     pub total_time: u64,
     pub total_break_time: u64,
     pub num_breaks: u64,
     pub total_time_to_do: u64,
     pub num_days: u64,
-    task_totals: HashMap<String,(u64, u64)>,
+    task_totals: HashMap<String, (u64, u64)>,
     pub starting_time_behind: i64,
 }
 
@@ -24,7 +23,7 @@ impl AggregateDay {
             total_time_to_do: 0,
             num_days: 0,
             task_totals: HashMap::new(),
-            starting_time_behind: starting_time_behind
+            starting_time_behind: starting_time_behind,
         };
     }
 
@@ -32,9 +31,15 @@ impl AggregateDay {
         if !day.has_ended() {
             return Err("Can't aggregate a day that hasn't ended!");
         }
-        self.total_time += day.get_day_length_secs().expect("Day has ended so day length should be known.") as u64;
-        self.total_break_time += day.get_total_break_time_secs().expect("Day has ended so day length should be known.") as u64;
-        self.num_breaks += day.get_number_of_breaks().expect("Day has ended so day length should be known.");
+        self.total_time +=
+            day.get_day_length_secs()
+                .expect("Day has ended so day length should be known.") as u64;
+        self.total_break_time +=
+            day.get_total_break_time_secs()
+                .expect("Day has ended so day length should be known.") as u64;
+        self.num_breaks += day
+            .get_number_of_breaks()
+            .expect("Day has ended so day length should be known.");
         self.total_time_to_do += day.get_time_to_do_secs();
         self.num_days += 1;
 
@@ -42,9 +47,13 @@ impl AggregateDay {
         let old_task_totals: HashMap<String, (u64, u64)> = self.task_totals.clone();
         for task_name in day.get_tasks_in_chronological_order() {
             let (time, blocks) = task_summaries.get(&task_name).unwrap();
-            let (curr_time, curr_blocks): (u64, u64) = *old_task_totals.get(&task_name).unwrap_or(&(0, 0));
+            let (curr_time, curr_blocks): (u64, u64) =
+                *old_task_totals.get(&task_name).unwrap_or(&(0, 0));
 
-            self.task_totals.insert(task_name, (curr_time + (*time as u64), curr_blocks + blocks));
+            self.task_totals.insert(
+                task_name,
+                (curr_time + (*time as u64), curr_blocks + blocks),
+            );
         }
         return Ok(());
     }
@@ -62,42 +71,71 @@ impl AggregateDay {
     }
 
     pub fn get_total_blocks(&self) -> u64 {
-        return self.task_totals.clone().into_iter().map(|(_x, (_y, z))| z).sum();
+        return self
+            .task_totals
+            .clone()
+            .into_iter()
+            .map(|(_x, (_y, z))| z)
+            .sum();
     }
 
     pub fn get_total_non_break_blocks(&self) -> u64 {
         return self.get_total_blocks() - self.num_breaks;
     }
 
-    pub fn render_human_readable_summary(&self, include_overall_time_behind: bool, show_times_in_hours: bool) -> Result<String, String> {
+    pub fn render_human_readable_summary(
+        &self,
+        include_overall_time_behind: bool,
+        show_times_in_hours: bool,
+    ) -> Result<String, String> {
         let mut summary_str: String = format!("Num days summarised: {}", self.num_days);
         summary_str += &format!(
-            "\nTotal work time (including breaks): {}", render_seconds_human_readable(self.total_time as i64, show_times_in_hours));
+            "\nTotal work time (including breaks): {}",
+            render_seconds_human_readable(self.total_time as i64, show_times_in_hours)
+        );
         summary_str += &format!(
-            "\nTotal time working (excluding breaks): {}", render_seconds_human_readable(self.get_total_time_done() as i64, show_times_in_hours));
+            "\nTotal time working (excluding breaks): {}",
+            render_seconds_human_readable(self.get_total_time_done() as i64, show_times_in_hours)
+        );
         summary_str += &format!(
-            "\nTotal time spent on break: {}", render_seconds_human_readable(self.total_break_time as i64, show_times_in_hours));
+            "\nTotal time spent on break: {}",
+            render_seconds_human_readable(self.total_break_time as i64, show_times_in_hours)
+        );
         summary_str += "\n";
-        
+
         summary_str += &format!(
-            "\nTotal task blocks (including breaks): {}", self.get_total_blocks());
+            "\nTotal task blocks (including breaks): {}",
+            self.get_total_blocks()
+        );
         summary_str += &format!(
-            "\nTotal task blocks (excluding breaks): {}", self.get_total_non_break_blocks());
+            "\nTotal task blocks (excluding breaks): {}",
+            self.get_total_non_break_blocks()
+        );
         summary_str += &format!("\nTotal breaks: {}", self.num_breaks);
         summary_str += "\n";
         summary_str += &"\nTask times, blocks:";
         for (task_name, (time, blocks)) in self.task_totals.clone().into_iter() {
-            summary_str += &format!("\n\t{}: {}, {} blocks", task_name, render_seconds_human_readable(time as i64, show_times_in_hours), blocks);
+            summary_str += &format!(
+                "\n\t{}: {}, {} blocks",
+                task_name,
+                render_seconds_human_readable(time as i64, show_times_in_hours),
+                blocks
+            );
         }
         summary_str += "\n";
 
-        summary_str += &format!("\nTime to do over period: {}", render_seconds_human_readable(self.total_time_to_do as i64, show_times_in_hours));
         summary_str += &format!(
-            "\nTime behind over period: {}", render_seconds_human_readable(self.get_time_behind_over_period(), show_times_in_hours), 
+            "\nTime to do over period: {}",
+            render_seconds_human_readable(self.total_time_to_do as i64, show_times_in_hours)
+        );
+        summary_str += &format!(
+            "\nTime behind over period: {}",
+            render_seconds_human_readable(self.get_time_behind_over_period(), show_times_in_hours),
         );
         if include_overall_time_behind {
             summary_str += &format!(
-                "\nTime behind overall: {}", render_seconds_human_readable(self.get_time_behind_overall(), show_times_in_hours), 
+                "\nTime behind overall: {}",
+                render_seconds_human_readable(self.get_time_behind_overall(), show_times_in_hours),
             );
         }
         return Ok(summary_str);

--- a/src/units/components.rs
+++ b/src/units/components.rs
@@ -1,9 +1,9 @@
 use chrono::prelude::{DateTime, Local};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-use crate::units::interval::{Dt,Interval};
+use crate::units::interval::{Dt, Interval};
 
-#[derive(Debug,Serialize,Deserialize,Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Note {
     time: Dt,
     msg: String,
@@ -18,7 +18,7 @@ impl Note {
     }
 }
 
-#[derive(Debug,Serialize,Deserialize,Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TimeBlock {
     task_name: String,
     interval: Interval,

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -276,10 +276,6 @@ impl Day {
         };
     }
 
-    pub fn get_time_to_do(&self) -> u64 {
-        return self.time_to_do;
-    }
-
     pub fn get_time_to_do_secs(&self) -> u64 {
         return self.time_to_do * 60 + self.time_to_do_seconds_in_addition.unwrap_or(0);
     }

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -29,11 +29,12 @@ pub struct Day {
     breaks: Vec<usize>,
     pub on_break: bool,
     pub time_to_do: u64,
+    pub time_to_do_seconds_in_addition: Option<u64>,
     pub summaries: Vec<WorkSummary>,
 }
 
 impl Day {
-    pub fn new(start: &DateTime<Local>, initial_task: String, time_to_do: u64) -> Self {
+    pub fn new(start: &DateTime<Local>, initial_task: String, time_to_do: u64, time_to_do_seconds_in_addition: Option<u64>) -> Self {
         let initial_block: TimeBlock = TimeBlock::new(initial_task.clone(), start);
         return Self {
             overall_interval: Interval::new(start),
@@ -42,6 +43,7 @@ impl Day {
             breaks: Vec::new(),
             on_break: false, 
             time_to_do: time_to_do,
+            time_to_do_seconds_in_addition: time_to_do_seconds_in_addition,
             summaries: Vec::new(),
         };
     }
@@ -272,12 +274,12 @@ impl Day {
     }
 
     pub fn get_time_to_do_secs(&self) -> u64 {
-        return self.time_to_do * 60;
+        return self.time_to_do * 60 + self.time_to_do_seconds_in_addition.unwrap_or(0);
     }
 
     pub fn get_time_left_secs(&self) -> Option<i64> {
         return match self.get_time_done_secs() {
-            Some(td) => Some((self.get_time_to_do() * 60) as i64 - td),
+            Some(td) => Some((self.get_time_to_do_secs()) as i64 - td),
             None => None,
         }
     }

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -54,9 +54,9 @@ impl Day {
         }
         self.overall_interval.end_at(at);
         if time_to_do_done {
-            let total_time_done = self.get_time_done_secs();
-            let minutes_done = total_time_done / 60;
-            let seconds_in_addition_done = total_time_done % 60;
+            let total_time_done: u64 = self.get_time_done_secs().unwrap() as u64;
+            let minutes_done: u64 = total_time_done / 60;
+            let seconds_in_addition_done: u64 = total_time_done % 60;
             self.time_to_do = minutes_done;
             self.time_to_do_seconds_in_addition = Some(seconds_in_addition_done);
         }

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -48,11 +48,18 @@ impl Day {
         };
     }
 
-    pub fn end_day_at(&mut self, at: &DateTime<Local>) -> Result<(), &str> {
+    pub fn end_day_at(&mut self, at: &DateTime<Local>, time_to_do_done: bool) -> Result<(), &str> {
         if self.has_ended() {
             return Err("Can't end the day because the day has already ended!");
         }
         self.overall_interval.end_at(at);
+        if time_to_do_done {
+            let total_time_done = self.get_time_done_secs();
+            let minutes_done = total_time_done / 60;
+            let seconds_in_addition_done = total_time_done % 60;
+            self.time_to_do = minutes_done;
+            self.time_to_do_seconds_in_addition = Some(seconds_in_addition_done);
+        }
         let block_result: Result<(), &str> = self.end_current_block_at(at);
         match block_result {
             Ok(_) => return Ok(()),

--- a/src/units/interval.rs
+++ b/src/units/interval.rs
@@ -1,12 +1,11 @@
-use std::fmt::{self};
-use chrono::prelude::{DateTime,Local};
+use chrono::prelude::{DateTime, Local};
 use serde::de;
-use serde::{Serialize, Deserialize, Serializer, Deserializer};
 use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{self};
 
 pub const DATETIME_FMT: &str = "%Y-%m-%d %H:%M:%S %z";
 pub const DATE_FMT: &str = "%Y-%m-%d";
-
 
 struct DtVisitor;
 
@@ -24,11 +23,11 @@ impl<'de> Visitor<'de> for DtVisitor {
         return match DateTime::parse_from_str(&s, DATETIME_FMT) {
             Ok(time) => Ok(Dt::new(time.with_timezone(&Local))),
             Err(_) => Err(E::custom("Incorrect format for string")),
-        }
+        };
     }
 }
 
-#[derive(Debug,Copy,Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct Dt(pub DateTime<Local>);
 
 impl Dt {
@@ -69,7 +68,7 @@ impl<'de> Deserialize<'de> for Dt {
     }
 }
 
-#[derive(Debug,Copy,Clone,Serialize,Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub struct Interval {
     start: Dt,
     end: Option<Dt>,
@@ -77,7 +76,10 @@ pub struct Interval {
 
 impl Interval {
     pub fn new(start: &DateTime<Local>) -> Self {
-        return Self {start: Dt(*start), end: None};
+        return Self {
+            start: Dt(*start),
+            end: None,
+        };
     }
 
     #[allow(dead_code)]
@@ -136,8 +138,8 @@ impl Interval {
     pub fn get_length_secs(&self) -> Option<i64> {
         return match self.get_end() {
             Some(end_time) => Some((end_time.0 - self.start.0).num_seconds()),
-            None => None, 
-        }
+            None => None,
+        };
     }
 
     pub fn get_length_mins(&self) -> Option<i64> {

--- a/src/units/mod.rs
+++ b/src/units/mod.rs
@@ -1,4 +1,4 @@
 pub mod aggregate_day;
+pub mod components;
 pub mod day;
 pub mod interval;
-pub mod components;

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -61,9 +61,6 @@ impl Config {
         return self.minutes_behind;
     }
 
-    pub fn minutes_behind_non_neg(&self) -> u64 {
-        return self.minutes_behind_non_neg;
-    }
     pub fn editor_path(&self) -> Option<&String> { return self.editor_path.as_ref(); }
 
     pub fn show_times_in_hours_or_default(&self) -> bool { 

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -1,6 +1,8 @@
-use serde::{Serialize, Deserialize};
+use crate::utils::file_io::{
+    expand_path, read_file, write_file, FromString, SafeFileEdit, ToFile, BASE_DIR,
+};
+use serde::{Deserialize, Serialize};
 use std::path::Path;
-use crate::utils::file_io::{expand_path, write_file, read_file, BASE_DIR, FromString, ToFile, SafeFileEdit};
 
 pub const CONFIG_FILE: &str = "punch.cfg";
 const DEFAULT_TIME_MINS: i64 = 480;
@@ -17,7 +19,7 @@ pub struct Config {
     seconds_behind_in_addition: Option<i64>,
     minutes_behind_non_neg: u64,
     editor_path: Option<String>,
-    show_times_in_hours: Option<bool>
+    show_times_in_hours: Option<bool>,
 }
 
 impl Config {
@@ -27,15 +29,19 @@ impl Config {
         default_break_task: String,
         minutes_behind: i64,
         seconds_behind_in_addition: Option<i64>,
-        show_times_in_hours: Option<bool>)
-        -> Self {
+        show_times_in_hours: Option<bool>,
+    ) -> Self {
         return Self {
             day_in_minutes: day_length,
             default_punch_in_task: default_punch_in_task,
             default_break_task: default_break_task,
             minutes_behind: minutes_behind,
             seconds_behind_in_addition: seconds_behind_in_addition,
-            minutes_behind_non_neg: if minutes_behind < 0 { 0 } else { minutes_behind } as u64,
+            minutes_behind_non_neg: if minutes_behind < 0 {
+                0
+            } else {
+                minutes_behind
+            } as u64,
             editor_path: Some("vim".to_string()),
             show_times_in_hours: show_times_in_hours,
         };
@@ -61,10 +67,14 @@ impl Config {
         return self.minutes_behind;
     }
 
-    pub fn editor_path(&self) -> Option<&String> { return self.editor_path.as_ref(); }
+    pub fn editor_path(&self) -> Option<&String> {
+        return self.editor_path.as_ref();
+    }
 
-    pub fn show_times_in_hours_or_default(&self) -> bool { 
-        return self.show_times_in_hours.unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT); 
+    pub fn show_times_in_hours_or_default(&self) -> bool {
+        return self
+            .show_times_in_hours
+            .unwrap_or(SHOW_TIMES_IN_HOURS_DEFAULT);
     }
 
     pub fn get_seconds_behind(&self) -> i64 {
@@ -132,7 +142,8 @@ pub fn create_default_config_if_not_exists() {
             DEFAULT_BREAK_TASK.to_owned(),
             0,
             Some(0),
-            Some(SHOW_TIMES_IN_HOURS_DEFAULT));
+            Some(SHOW_TIMES_IN_HOURS_DEFAULT),
+        );
         write_config(&config_path, &default_config);
     }
 }
@@ -146,7 +157,6 @@ pub fn get_config() -> Config {
 pub fn get_config_path() -> String {
     return expand_path(&(BASE_DIR.to_owned() + &(CONFIG_FILE.to_owned())));
 }
-
 
 pub fn update_config(config: Config) {
     let config_path: String = expand_path(&(BASE_DIR.to_owned() + &(CONFIG_FILE.to_owned())));

--- a/src/utils/dates_and_times.rs
+++ b/src/utils/dates_and_times.rs
@@ -15,7 +15,6 @@ impl Iterator for DateRange {
     }
 }
 
-
 pub fn get_local_now() -> DateTime<Local> {
     return Local::now();
 }

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -1,21 +1,27 @@
-use std::collections::HashMap;
 use regex::Regex;
+use std::collections::HashMap;
 
 pub fn render_seconds_human_readable(secs: i64, show_times_in_hours: bool) -> String {
-    let (sign, sign_str): (i64, &str) = if secs < 0 {(-1, "-")} else {(1, "")};
+    let (sign, sign_str): (i64, &str) = if secs < 0 { (-1, "-") } else { (1, "") };
     let abs_secs: i64 = sign * secs;
     let abs_output: String;
     if show_times_in_hours & (abs_secs >= 60 * 60) {
         let hours: i64 = abs_secs / (60 * 60);
-        let seconds_left:i64 = abs_secs % (60 * 60);
-        abs_output =  format!("{}h {}", hours, render_seconds_human_readable(seconds_left, false));
-    }
-    else if abs_secs >= 60 {
+        let seconds_left: i64 = abs_secs % (60 * 60);
+        abs_output = format!(
+            "{}h {}",
+            hours,
+            render_seconds_human_readable(seconds_left, false)
+        );
+    } else if abs_secs >= 60 {
         let minutes: i64 = abs_secs / 60;
         let seconds_left: i64 = abs_secs % 60;
-        abs_output = format!("{}m {}", minutes, render_seconds_human_readable(seconds_left, false));
-    }
-    else {
+        abs_output = format!(
+            "{}m {}",
+            minutes,
+            render_seconds_human_readable(seconds_left, false)
+        );
+    } else {
         abs_output = format!("{}s", abs_secs);
     }
     return format!("{}{}", sign_str, abs_output);
@@ -39,7 +45,7 @@ pub fn convert_input_to_seconds(input_str: &str) -> Result<i64, String> {
 
     let units_to_secs: HashMap<&str, i64> = HashMap::from([("h", 60 * 60), ("m", 60), ("s", 1)]);
     let re = Regex::new(r"(\d+)([hms])").unwrap();
-    let sign: i64 = if rest.starts_with('-') {-1} else {1};
+    let sign: i64 = if rest.starts_with('-') { -1 } else { 1 };
     for (_, [amount, unit]) in re.captures_iter(&rest).map(|c| c.extract()) {
         let parse_result = amount.parse::<i64>();
         if let Err(_) = parse_result {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,5 @@
-pub mod file_io;
 pub mod config;
 pub mod dates_and_times;
-pub mod work_summary;
+pub mod file_io;
 pub mod misc;
+pub mod work_summary;

--- a/src/utils/work_summary.rs
+++ b/src/utils/work_summary.rs
@@ -1,6 +1,6 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug,Serialize,Deserialize,Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WorkSummary {
     category: String,
     project: String,


### PR DESCRIPTION
This PR:
1. Adds more accurate time behind by allowing us to track seconds as well (#67 )
2. Allows for second resolution time to do which paves the way for
3. Adds a new flag for punch out: "--time-to-do-done" or "-d". This sets the time to do for the day to be exactly the same as the time done. This has the effect of punching out not changing how far ahead/behind the user is (#75)
4. Now punch --version reads the version from the package information, rather than us having to manually update this every time (#54 )
5. Updated the README to inform users that you no longer have to use vim as the editor and to give guidance on how to do this for GUI based editors (#81)
6. Also set the `minutes_behind_non_neg` to 0 since we're not using it anyway at the moment (#65)