### PR TITLE
Fixed some time behind related bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "punch"
-version = "2.5.2"
+version = "2.5.3"
 edition = "2021"
 
 [dependencies]

--- a/src/commands/core.rs
+++ b/src/commands/core.rs
@@ -191,7 +191,7 @@ pub fn punch_back_in(now: &DateTime<Local>, other_args: Vec<String>, mut day: Da
                 .expect("We should be able to end the day");
         }
         let mut config: Config = get_config();
-        config.update_minutes_behind(-seconds_left_before / 60);
+        config.update_time_behind(-seconds_left_before);
         update_config(config);
 
         let summary_result = print_day_summary(&day, true);

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -270,7 +270,7 @@ pub fn print_day_summary(day: &Day, use_config_for_time_behind: bool) -> Result<
     let config: Config = get_config();
     let show_times_in_hours = config.show_times_in_hours_or_default();
     let time_behind_opt: Option<i64> = match use_config_for_time_behind {
-        true => Some(config.minutes_behind() * 60),
+        true => Some(config.get_seconds_behind() * 60),
         false => None,
     };
     let summary_result: Result<String, String> =

--- a/src/commands/day_summaries.rs
+++ b/src/commands/day_summaries.rs
@@ -270,7 +270,7 @@ pub fn print_day_summary(day: &Day, use_config_for_time_behind: bool) -> Result<
     let config: Config = get_config();
     let show_times_in_hours = config.show_times_in_hours_or_default();
     let time_behind_opt: Option<i64> = match use_config_for_time_behind {
-        true => Some(config.get_seconds_behind() * 60),
+        true => Some(config.get_seconds_behind()),
         false => None,
     };
     let summary_result: Result<String, String> =

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -52,7 +52,7 @@ impl Day {
             return Err("Can't end the day because the day has already ended!");
         }
         self.overall_interval.end_at(at);
-        if time_to_do_done {
+        if time_to_do_done & (self.get_time_left_secs().expect("Day should have already ended") > 0) {
             let total_time_done: u64 = self.get_time_done_secs().unwrap() as u64;
             let minutes_done: u64 = total_time_done / 60;
             let seconds_in_addition_done: u64 = total_time_done % 60;

--- a/src/units/day.rs
+++ b/src/units/day.rs
@@ -52,7 +52,7 @@ impl Day {
             return Err("Can't end the day because the day has already ended!");
         }
         self.overall_interval.end_at(at);
-        if time_to_do_done & (self.get_time_left_secs().expect("Day should have already ended") > 0) {
+        if time_to_do_done {
             let total_time_done: u64 = self.get_time_done_secs().unwrap() as u64;
             let minutes_done: u64 = total_time_done / 60;
             let seconds_in_addition_done: u64 = total_time_done % 60;

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -89,7 +89,7 @@ impl Config {
         let sign: i64 = new_total_seconds_behind.signum();
         let abs_seconds_behind: i64 = new_total_seconds_behind.abs();
         let new_minutes_behind: i64 = abs_seconds_behind / 60;
-        let new_seconds_in_addition: i64 = new_total_seconds_behind % 60;
+        let new_seconds_in_addition: i64 = abs_seconds_behind % 60;
         self.minutes_behind = sign * new_minutes_behind;
         self.seconds_behind_in_addition = Some(sign * new_seconds_in_addition);
     }


### PR DESCRIPTION
Three bugs fixed:
1. Config sets seconds incorrectly as positive when we're actually ahead on time
2. Time behind in summaries only uses minutes not seconds to calculate total time behind #83 
3. Config update for`punch back-in` only updates based on the minutes behind. Updated to do full time now